### PR TITLE
Implement page to show and edit individual entries

### DIFF
--- a/journal-app/app/controllers/entries_controller.rb
+++ b/journal-app/app/controllers/entries_controller.rb
@@ -17,9 +17,23 @@ class EntriesController < ApplicationController
         end
     end
 
+    def show
+        @entry = Entry.find(params[:id])
+
+    end
+
     def destroy
         Entry.find(params[:id]).destroy
         redirect_to root_url
+    end
+
+    def update
+        @entry = Entry.find(params[:id])
+        if @entry.update(entry_params)
+          redirect_to @entry, notice: "Entry successfully updated."
+        else
+          render :edit
+        end
     end
  
     private
@@ -27,4 +41,6 @@ class EntriesController < ApplicationController
     def entry_params
         params.require(:entry).permit(:name, :link)
     end
+
+    
  end

--- a/journal-app/app/views/entries/index.html.erb
+++ b/journal-app/app/views/entries/index.html.erb
@@ -1,8 +1,4 @@
 <h1>All Entries</h1>
 <div>
- <% @entries.each do |entry| %>
-   <%= entry.name %>
-   <%= entry.link %>
-   <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
- <% end %>
+  <%= render partial: "shared/entry", collection: @entries %>
 </div>

--- a/journal-app/app/views/entries/show.html.erb
+++ b/journal-app/app/views/entries/show.html.erb
@@ -1,0 +1,24 @@
+<h1><%=@entry.name%></h1>
+
+<%= form_with(model: @entry, method: :patch) do |form| %>
+  <div>
+    <%= @entry.name %>
+    <%= form.label :name %>
+    <%= form.text_field :name %>
+    <br/>
+    <%= @entry.link %>
+    <%= form.label :link %>
+    <%= form.text_field :link %>
+  </div>
+  
+  <div>
+    <%= form.submit "Update Entry" %>
+  </div>
+<% end %>
+
+<br>
+
+<div>
+  <%= link_to "Back to entries", entries_path %>
+  <%= link_to "Show this entry", @entry %>
+</div>

--- a/journal-app/app/views/shared/_entry.html.erb
+++ b/journal-app/app/views/shared/_entry.html.erb
@@ -1,0 +1,6 @@
+<div class="entry">
+  <%= entry.name %>
+  <%= entry.link %>
+  <%= button_to "Edit Entry", entry, method: :get %>
+  <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+</div>

--- a/journal-app/config/routes.rb
+++ b/journal-app/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
 
   root 'entries#index'
-  resources :entries, only: [:create, :new, :destroy]
+  resources :entries, only: [:create, :new, :destroy, :show, :edit, :update]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/journal-app/log/development.log
+++ b/journal-app/log/development.log
@@ -1155,3 +1155,3772 @@ Processing by EntriesController#new as HTML
 Completed 200 OK in 13ms (Views: 11.5ms | ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 1.0ms)
 
 
+Started GET "/" for ::1 at 2025-04-01 14:38:58 +0100
+  [1m[36mActiveRecord::SchemaMigration Load (0.8ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (9.5ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 4.2ms | GC: 0.2ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 24.4ms | GC: 0.7ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.2ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 97.8ms | GC: 34.0ms)
+Completed 200 OK in 116ms (Views: 79.9ms | ActiveRecord: 20.8ms (1 query, 0 cached) | GC: 34.4ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 14:39:22 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.8ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 1.0ms | GC: 0.0ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 8.2ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 15.3ms | GC: 0.2ms)
+Completed 200 OK in 17ms (Views: 11.0ms | ActiveRecord: 4.9ms (1 query, 0 cached) | GC: 0.2ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 14:43:08 +0100
+  [1m[36mActiveRecord::SchemaMigration Load (1.2ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (14.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 10.6ms | GC: 0.4ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 36.6ms | GC: 0.8ms)
+  Rendered layout layouts/application.html.erb (Duration: 36.7ms | GC: 0.8ms)
+Completed 500 Internal Server Error in 48ms (ActiveRecord: 28.6ms (1 query, 0 cached) | GC: 1.2ms)
+
+
+  
+ActionView::Template::Error (undefined local variable or method `edit_entry_path' for #<ActionView::Base:0x0000000000bfe0>):
+
+Causes:
+NameError (undefined local variable or method `edit_entry_path' for #<ActionView::Base:0x0000000000bfe0>)
+    1: <div class="entry">
+    2:   <%= entry.name %>
+    3:   <%= entry.link %>
+    4:   <%= link_to "Edit Entry", edit_entry_path %>
+    5:   <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+    6:   
+    7: </div>
+  
+app/views/shared/_entry.html.erb:4
+app/views/entries/index.html.erb:3
+Started GET "/entries/new" for ::1 at 2025-04-01 14:43:19 +0100
+Processing by EntriesController#new as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/new.html.erb within layouts/application
+  Rendered entries/new.html.erb within layouts/application (Duration: 6.8ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.3ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 49.5ms | GC: 2.4ms)
+Completed 200 OK in 52ms (Views: 49.9ms | ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 2.7ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 14:48:31 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.5ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 8.7ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 16.3ms | GC: 0.3ms)
+  Rendered layout layouts/application.html.erb (Duration: 16.4ms | GC: 0.3ms)
+Completed 500 Internal Server Error in 18ms (ActiveRecord: 5.5ms (1 query, 0 cached) | GC: 0.4ms)
+
+
+  
+ActionView::Template::Error (undefined local variable or method `edit_entry_path' for #<ActionView::Base:0x0000000000fbb8>):
+
+Causes:
+NameError (undefined local variable or method `edit_entry_path' for #<ActionView::Base:0x0000000000fbb8>)
+    1: <div class="entry">
+    2:   <%= entry.name %>
+    3:   <%= entry.link %>
+    4:   <%= link_to "Edit Entry", edit_entry_path %>
+    5:   <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+    6: </div>
+  
+app/views/shared/_entry.html.erb:4
+app/views/entries/index.html.erb:3
+Started GET "/" for ::1 at 2025-04-01 14:49:23 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.3ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 0.7ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 7.2ms | GC: 0.2ms)
+  Rendered layout layouts/application.html.erb (Duration: 7.3ms | GC: 0.2ms)
+Completed 500 Internal Server Error in 9ms (ActiveRecord: 4.5ms (1 query, 0 cached) | GC: 0.2ms)
+
+
+  
+ActionView::Template::Error (No route matches {:action=>"edit", :controller=>"entries"}, missing required keys: [:id]
+Did you mean?  edit_entry_url):
+
+Causes:
+ActionController::UrlGenerationError (No route matches {:action=>"edit", :controller=>"entries"}, missing required keys: [:id]
+Did you mean?  edit_entry_url)
+    1: <div class="entry">
+    2:   <%= entry.name %>
+    3:   <%= entry.link %>
+    4:   <%= link_to "Edit Entry", edit_entry_path %>
+    5:   <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+    6: </div>
+  
+app/views/shared/_entry.html.erb:4
+app/views/entries/index.html.erb:3
+Started GET "/" for ::1 at 2025-04-01 14:50:09 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.5ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 0.6ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 8.7ms | GC: 0.3ms)
+  Rendered layout layouts/application.html.erb (Duration: 8.8ms | GC: 0.3ms)
+Completed 500 Internal Server Error in 13ms (ActiveRecord: 5.5ms (1 query, 0 cached) | GC: 2.3ms)
+
+
+  
+ActionView::Template::Error (No route matches {:action=>"edit", :controller=>"entries", :id=>nil}, missing required keys: [:id]):
+
+Causes:
+ActionController::UrlGenerationError (No route matches {:action=>"edit", :controller=>"entries", :id=>nil}, missing required keys: [:id])
+    1: <div class="entry">
+    2:   <%= entry.name %>
+    3:   <%= entry.link %>
+    4:   <%= link_to "Edit Entry", edit_entry_path(@entry) %>
+    5:   <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+    6: </div>
+  
+app/views/shared/_entry.html.erb:4
+app/views/entries/index.html.erb:3
+Started GET "/" for ::1 at 2025-04-01 14:50:10 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.9ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 0.6ms | GC: 0.0ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 3.5ms | GC: 0.2ms)
+  Rendered layout layouts/application.html.erb (Duration: 3.7ms | GC: 0.2ms)
+Completed 500 Internal Server Error in 6ms (ActiveRecord: 0.9ms (1 query, 0 cached) | GC: 0.2ms)
+
+
+  
+ActionView::Template::Error (No route matches {:action=>"edit", :controller=>"entries", :id=>nil}, missing required keys: [:id]):
+
+Causes:
+ActionController::UrlGenerationError (No route matches {:action=>"edit", :controller=>"entries", :id=>nil}, missing required keys: [:id])
+    1: <div class="entry">
+    2:   <%= entry.name %>
+    3:   <%= entry.link %>
+    4:   <%= link_to "Edit Entry", edit_entry_path(@entry) %>
+    5:   <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+    6: </div>
+  
+app/views/shared/_entry.html.erb:4
+app/views/entries/index.html.erb:3
+Started GET "/" for ::1 at 2025-04-01 14:50:11 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (1.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 1.3ms | GC: 0.3ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 8.7ms | GC: 0.3ms)
+  Rendered layout layouts/application.html.erb (Duration: 9.3ms | GC: 0.3ms)
+Completed 500 Internal Server Error in 13ms (ActiveRecord: 1.1ms (1 query, 0 cached) | GC: 0.3ms)
+
+
+  
+ActionView::Template::Error (No route matches {:action=>"edit", :controller=>"entries", :id=>nil}, missing required keys: [:id]):
+
+Causes:
+ActionController::UrlGenerationError (No route matches {:action=>"edit", :controller=>"entries", :id=>nil}, missing required keys: [:id])
+    1: <div class="entry">
+    2:   <%= entry.name %>
+    3:   <%= entry.link %>
+    4:   <%= link_to "Edit Entry", edit_entry_path(@entry) %>
+    5:   <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+    6: </div>
+  
+app/views/shared/_entry.html.erb:4
+app/views/entries/index.html.erb:3
+Started GET "/" for ::1 at 2025-04-01 14:50:12 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.5ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 0.8ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 4.4ms | GC: 0.1ms)
+  Rendered layout layouts/application.html.erb (Duration: 4.7ms | GC: 0.1ms)
+Completed 500 Internal Server Error in 6ms (ActiveRecord: 0.5ms (1 query, 0 cached) | GC: 0.1ms)
+
+
+  
+ActionView::Template::Error (No route matches {:action=>"edit", :controller=>"entries", :id=>nil}, missing required keys: [:id]):
+
+Causes:
+ActionController::UrlGenerationError (No route matches {:action=>"edit", :controller=>"entries", :id=>nil}, missing required keys: [:id])
+    1: <div class="entry">
+    2:   <%= entry.name %>
+    3:   <%= entry.link %>
+    4:   <%= link_to "Edit Entry", edit_entry_path(@entry) %>
+    5:   <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+    6: </div>
+  
+app/views/shared/_entry.html.erb:4
+app/views/entries/index.html.erb:3
+Started GET "/" for ::1 at 2025-04-01 14:51:21 +0100
+  
+SyntaxError (/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/controllers/entries_controller.rb:35: syntax error, unexpected end-of-input, expecting `end'):
+  
+app/controllers/entries_controller.rb:35: syntax error, unexpected end-of-input, expecting `end'
+Started GET "/" for ::1 at 2025-04-01 14:51:22 +0100
+  
+SyntaxError (/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/controllers/entries_controller.rb:35: syntax error, unexpected end-of-input, expecting `end'):
+  
+app/controllers/entries_controller.rb:35: syntax error, unexpected end-of-input, expecting `end'
+Started GET "/" for ::1 at 2025-04-01 14:51:32 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (1.0ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 0.9ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 12.7ms | GC: 0.2ms)
+  Rendered layout layouts/application.html.erb (Duration: 12.9ms | GC: 0.2ms)
+Completed 500 Internal Server Error in 17ms (ActiveRecord: 7.5ms (1 query, 0 cached) | GC: 0.4ms)
+
+
+  
+ActionView::Template::Error (No route matches {:action=>"edit", :controller=>"entries", :id=>nil}, missing required keys: [:id]):
+
+Causes:
+ActionController::UrlGenerationError (No route matches {:action=>"edit", :controller=>"entries", :id=>nil}, missing required keys: [:id])
+    1: <div class="entry">
+    2:   <%= entry.name %>
+    3:   <%= entry.link %>
+    4:   <%= link_to "Edit Entry", edit_entry_path(@entry) %>
+    5:   <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+    6: </div>
+  
+app/views/shared/_entry.html.erb:4
+app/views/entries/index.html.erb:3
+Started GET "/" for ::1 at 2025-04-01 14:51:33 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 0.6ms | GC: 0.0ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 3.1ms | GC: 0.2ms)
+  Rendered layout layouts/application.html.erb (Duration: 3.3ms | GC: 0.2ms)
+Completed 500 Internal Server Error in 6ms (ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 0.2ms)
+
+
+  
+ActionView::Template::Error (No route matches {:action=>"edit", :controller=>"entries", :id=>nil}, missing required keys: [:id]):
+
+Causes:
+ActionController::UrlGenerationError (No route matches {:action=>"edit", :controller=>"entries", :id=>nil}, missing required keys: [:id])
+    1: <div class="entry">
+    2:   <%= entry.name %>
+    3:   <%= entry.link %>
+    4:   <%= link_to "Edit Entry", edit_entry_path(@entry) %>
+    5:   <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+    6: </div>
+  
+app/views/shared/_entry.html.erb:4
+app/views/entries/index.html.erb:3
+Started GET "/" for ::1 at 2025-04-01 14:51:47 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 0.6ms | GC: 0.0ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 6.5ms | GC: 0.2ms)
+  Rendered layout layouts/application.html.erb (Duration: 6.6ms | GC: 0.2ms)
+Completed 500 Internal Server Error in 8ms (ActiveRecord: 3.6ms (1 query, 0 cached) | GC: 0.3ms)
+
+
+  
+ActionView::Template::Error (No route matches {:action=>"edit", :controller=>"entries"}, missing required keys: [:id]
+Did you mean?  edit_entry_url):
+
+Causes:
+ActionController::UrlGenerationError (No route matches {:action=>"edit", :controller=>"entries"}, missing required keys: [:id]
+Did you mean?  edit_entry_url)
+    1: <div class="entry">
+    2:   <%= entry.name %>
+    3:   <%= entry.link %>
+    4:   <%= link_to "Edit Entry", edit_entry_path %>
+    5:   <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+    6: </div>
+  
+app/views/shared/_entry.html.erb:4
+app/views/entries/index.html.erb:3
+Started GET "/" for ::1 at 2025-04-01 14:52:13 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 0.4ms | GC: 0.0ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 7.2ms | GC: 0.1ms)
+  Rendered layout layouts/application.html.erb (Duration: 7.3ms | GC: 0.1ms)
+Completed 500 Internal Server Error in 9ms (ActiveRecord: 4.3ms (1 query, 0 cached) | GC: 0.2ms)
+
+
+  
+ActionView::SyntaxErrorInTemplate (Encountered a syntax error while rendering template: check <div class="entry">
+  <%= entry.name %>
+  <%= entry.link %>
+  <%= link_to "Edit Entry", entry, method :edit %>
+  <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+</div>
+):
+
+Causes:
+ActiveSupport::SyntaxErrorProxy (/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/shared/_entry.html.erb:4: syntax error, unexpected symbol literal, expecting `do' or '{' or '('
+...o "Edit Entry", entry, method :edit ); @output_buffer.safe_a...
+...                              ^
+)
+1:    <div class="entry">
+2:      <%= entry.name %>
+3:      <%= entry.link %>
+4:      <%= link_to "Edit Entry", entry, method :edit %>
+5:      <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+6:    </div>
+  
+app/views/shared/_entry.html.erb:4: syntax error, unexpected symbol literal, expecting `do' or '{' or '('
+app/views/entries/index.html.erb:3
+Started GET "/" for ::1 at 2025-04-01 14:52:16 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.7ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 1.0ms | GC: 0.2ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 3.2ms | GC: 0.2ms)
+  Rendered layout layouts/application.html.erb (Duration: 3.4ms | GC: 0.2ms)
+Completed 500 Internal Server Error in 6ms (ActiveRecord: 0.7ms (1 query, 0 cached) | GC: 0.2ms)
+
+
+  
+ActionView::SyntaxErrorInTemplate (Encountered a syntax error while rendering template: check <div class="entry">
+  <%= entry.name %>
+  <%= entry.link %>
+  <%= link_to "Edit Entry", entry, method :edit %>
+  <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+</div>
+):
+
+Causes:
+ActiveSupport::SyntaxErrorProxy (/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/shared/_entry.html.erb:4: syntax error, unexpected symbol literal, expecting `do' or '{' or '('
+...o "Edit Entry", entry, method :edit ); @output_buffer.safe_a...
+...                              ^
+)
+1:    <div class="entry">
+2:      <%= entry.name %>
+3:      <%= entry.link %>
+4:      <%= link_to "Edit Entry", entry, method :edit %>
+5:      <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+6:    </div>
+  
+app/views/shared/_entry.html.erb:4: syntax error, unexpected symbol literal, expecting `do' or '{' or '('
+app/views/entries/index.html.erb:3
+Started GET "/" for ::1 at 2025-04-01 14:52:19 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 0.5ms | GC: 0.0ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 2.1ms | GC: 0.1ms)
+  Rendered layout layouts/application.html.erb (Duration: 2.3ms | GC: 0.1ms)
+Completed 500 Internal Server Error in 3ms (ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 0.1ms)
+
+
+  
+ActionView::SyntaxErrorInTemplate (Encountered a syntax error while rendering template: check <div class="entry">
+  <%= entry.name %>
+  <%= entry.link %>
+  <%= link_to "Edit Entry", entry, method :edit %>
+  <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+</div>
+):
+
+Causes:
+ActiveSupport::SyntaxErrorProxy (/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/shared/_entry.html.erb:4: syntax error, unexpected symbol literal, expecting `do' or '{' or '('
+...o "Edit Entry", entry, method :edit ); @output_buffer.safe_a...
+...                              ^
+)
+1:    <div class="entry">
+2:      <%= entry.name %>
+3:      <%= entry.link %>
+4:      <%= link_to "Edit Entry", entry, method :edit %>
+5:      <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+6:    </div>
+  
+app/views/shared/_entry.html.erb:4: syntax error, unexpected symbol literal, expecting `do' or '{' or '('
+app/views/entries/index.html.erb:3
+Started GET "/" for ::1 at 2025-04-01 14:52:19 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.6ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 1.2ms | GC: 0.0ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 4.4ms | GC: 0.3ms)
+  Rendered layout layouts/application.html.erb (Duration: 4.7ms | GC: 0.3ms)
+Completed 500 Internal Server Error in 7ms (ActiveRecord: 0.6ms (1 query, 0 cached) | GC: 0.3ms)
+
+
+  
+ActionView::SyntaxErrorInTemplate (Encountered a syntax error while rendering template: check <div class="entry">
+  <%= entry.name %>
+  <%= entry.link %>
+  <%= link_to "Edit Entry", entry, method :edit %>
+  <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+</div>
+):
+
+Causes:
+ActiveSupport::SyntaxErrorProxy (/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/shared/_entry.html.erb:4: syntax error, unexpected symbol literal, expecting `do' or '{' or '('
+...o "Edit Entry", entry, method :edit ); @output_buffer.safe_a...
+...                              ^
+)
+1:    <div class="entry">
+2:      <%= entry.name %>
+3:      <%= entry.link %>
+4:      <%= link_to "Edit Entry", entry, method :edit %>
+5:      <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+6:    </div>
+  
+app/views/shared/_entry.html.erb:4: syntax error, unexpected symbol literal, expecting `do' or '{' or '('
+app/views/entries/index.html.erb:3
+Started GET "/" for ::1 at 2025-04-01 14:52:45 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 0.4ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 8.4ms | GC: 0.2ms)
+  Rendered layout layouts/application.html.erb (Duration: 8.5ms | GC: 0.2ms)
+Completed 500 Internal Server Error in 10ms (ActiveRecord: 5.7ms (1 query, 0 cached) | GC: 0.2ms)
+
+
+  
+ActionView::SyntaxErrorInTemplate (Encountered a syntax error while rendering template: check <div class="entry">
+  <%= entry.name %>
+  <%= entry.link %>
+  <%= link_to "Edit Entry", entry, method :edit %>
+  <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+</div>
+):
+
+Causes:
+ActiveSupport::SyntaxErrorProxy (/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/shared/_entry.html.erb:4: syntax error, unexpected symbol literal, expecting `do' or '{' or '('
+...o "Edit Entry", entry, method :edit ); @output_buffer.safe_a...
+...                              ^
+)
+1:    <div class="entry">
+2:      <%= entry.name %>
+3:      <%= entry.link %>
+4:      <%= link_to "Edit Entry", entry, method :edit %>
+5:      <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+6:    </div>
+  
+app/views/shared/_entry.html.erb:4: syntax error, unexpected symbol literal, expecting `do' or '{' or '('
+app/views/entries/index.html.erb:3
+Started GET "/" for ::1 at 2025-04-01 14:52:46 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.9ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 1.8ms | GC: 0.0ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 8.6ms | GC: 0.4ms)
+  Rendered layout layouts/application.html.erb (Duration: 9.0ms | GC: 0.4ms)
+Completed 500 Internal Server Error in 12ms (ActiveRecord: 0.9ms (1 query, 0 cached) | GC: 0.4ms)
+
+
+  
+ActionView::SyntaxErrorInTemplate (Encountered a syntax error while rendering template: check <div class="entry">
+  <%= entry.name %>
+  <%= entry.link %>
+  <%= link_to "Edit Entry", entry, method :edit %>
+  <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+</div>
+):
+
+Causes:
+ActiveSupport::SyntaxErrorProxy (/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/shared/_entry.html.erb:4: syntax error, unexpected symbol literal, expecting `do' or '{' or '('
+...o "Edit Entry", entry, method :edit ); @output_buffer.safe_a...
+...                              ^
+)
+1:    <div class="entry">
+2:      <%= entry.name %>
+3:      <%= entry.link %>
+4:      <%= link_to "Edit Entry", entry, method :edit %>
+5:      <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+6:    </div>
+  
+app/views/shared/_entry.html.erb:4: syntax error, unexpected symbol literal, expecting `do' or '{' or '('
+app/views/entries/index.html.erb:3
+Started GET "/" for ::1 at 2025-04-01 14:52:51 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 0.4ms | GC: 0.0ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 5.7ms | GC: 0.1ms)
+  Rendered layout layouts/application.html.erb (Duration: 5.8ms | GC: 0.1ms)
+Completed 500 Internal Server Error in 8ms (ActiveRecord: 3.2ms (1 query, 0 cached) | GC: 0.2ms)
+
+
+  
+ActionView::SyntaxErrorInTemplate (Encountered a syntax error while rendering template: check <div class="entry">
+  <%= entry.name %>
+  <%= entry.link %>
+  <%= link_to "Edit Entry", entry, method :edit %>
+  <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+</div>
+):
+
+Causes:
+ActiveSupport::SyntaxErrorProxy (/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/shared/_entry.html.erb:4: syntax error, unexpected symbol literal, expecting `do' or '{' or '('
+...o "Edit Entry", entry, method :edit ); @output_buffer.safe_a...
+...                              ^
+)
+1:    <div class="entry">
+2:      <%= entry.name %>
+3:      <%= entry.link %>
+4:      <%= link_to "Edit Entry", entry, method :edit %>
+5:      <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+6:    </div>
+  
+app/views/shared/_entry.html.erb:4: syntax error, unexpected symbol literal, expecting `do' or '{' or '('
+app/views/entries/index.html.erb:3
+Started GET "/" for ::1 at 2025-04-01 14:52:52 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (1.0ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 1.1ms | GC: 0.0ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 5.5ms | GC: 0.4ms)
+  Rendered layout layouts/application.html.erb (Duration: 5.8ms | GC: 0.4ms)
+Completed 500 Internal Server Error in 9ms (ActiveRecord: 1.0ms (1 query, 0 cached) | GC: 0.4ms)
+
+
+  
+ActionView::SyntaxErrorInTemplate (Encountered a syntax error while rendering template: check <div class="entry">
+  <%= entry.name %>
+  <%= entry.link %>
+  <%= link_to "Edit Entry", entry, method :edit %>
+  <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+</div>
+):
+
+Causes:
+ActiveSupport::SyntaxErrorProxy (/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/shared/_entry.html.erb:4: syntax error, unexpected symbol literal, expecting `do' or '{' or '('
+...o "Edit Entry", entry, method :edit ); @output_buffer.safe_a...
+...                              ^
+)
+1:    <div class="entry">
+2:      <%= entry.name %>
+3:      <%= entry.link %>
+4:      <%= link_to "Edit Entry", entry, method :edit %>
+5:      <%= button_to "Delete", entry, method: :delete, data: { confirm: "Are you sure you want to delete this Project ?"} %>
+6:    </div>
+  
+app/views/shared/_entry.html.erb:4: syntax error, unexpected symbol literal, expecting `do' or '{' or '('
+app/views/entries/index.html.erb:3
+Started GET "/" for ::1 at 2025-04-01 14:53:12 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 1.1ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 6.5ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.2ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 14.1ms | GC: 0.7ms)
+Completed 200 OK in 16ms (Views: 11.6ms | ActiveRecord: 3.1ms (1 query, 0 cached) | GC: 0.8ms)
+
+
+Started GET "/entries/4" for ::1 at 2025-04-01 14:53:13 +0100
+  
+ActionController::RoutingError (No route matches [GET] "/entries/4"):
+  
+Started GET "/entries/4" for ::1 at 2025-04-01 14:55:45 +0100
+  
+ActionController::RoutingError (No route matches [GET] "/entries/4"):
+  
+Started GET "/entries/4" for ::1 at 2025-04-01 14:55:45 +0100
+  
+ActionController::RoutingError (No route matches [GET] "/entries/4"):
+  
+Started GET "/entries/4" for ::1 at 2025-04-01 14:55:46 +0100
+  
+ActionController::RoutingError (No route matches [GET] "/entries/4"):
+  
+Started GET "/entries/4" for ::1 at 2025-04-01 14:55:46 +0100
+  
+ActionController::RoutingError (No route matches [GET] "/entries/4"):
+  
+Started GET "/entries/4" for ::1 at 2025-04-01 14:55:46 +0100
+  
+ActionController::RoutingError (No route matches [GET] "/entries/4"):
+  
+Started GET "/entries/4" for ::1 at 2025-04-01 14:55:46 +0100
+  
+ActionController::RoutingError (No route matches [GET] "/entries/4"):
+  
+Started GET "/entries/4" for ::1 at 2025-04-01 14:55:46 +0100
+  
+ActionController::RoutingError (No route matches [GET] "/entries/4"):
+  
+Started GET "/" for ::1 at 2025-04-01 14:55:55 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.8ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 2.0ms | GC: 0.2ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 12.0ms | GC: 0.6ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.4ms | GC: 0.2ms)
+  Rendered layout layouts/application.html.erb (Duration: 23.6ms | GC: 1.9ms)
+Completed 200 OK in 27ms (Views: 19.0ms | ActiveRecord: 5.5ms (1 query, 0 cached) | GC: 2.2ms)
+
+
+Started GET "/entries/2" for ::1 at 2025-04-01 14:55:56 +0100
+  
+ActionController::RoutingError (No route matches [GET] "/entries/2"):
+  
+Started GET "/entries/1" for ::1 at 2025-04-01 14:55:57 +0100
+  
+ActionController::RoutingError (No route matches [GET] "/entries/1"):
+  
+Started GET "/entries/4" for ::1 at 2025-04-01 14:55:59 +0100
+  
+ActionController::RoutingError (No route matches [GET] "/entries/4"):
+  
+Started GET "/entries/5" for ::1 at 2025-04-01 14:55:59 +0100
+  
+ActionController::RoutingError (No route matches [GET] "/entries/5"):
+  
+Started GET "/entries/1" for ::1 at 2025-04-01 14:56:00 +0100
+  
+ActionController::RoutingError (No route matches [GET] "/entries/1"):
+  
+Started GET "/" for ::1 at 2025-04-01 14:56:03 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.5ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 2.8ms | GC: 0.2ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 5.0ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 15.4ms | GC: 1.1ms)
+Completed 200 OK in 17ms (Views: 15.3ms | ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 1.1ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 14:56:04 +0100
+  
+ActionController::RoutingError (No route matches [GET] "/entries/1"):
+  
+Started GET "/" for ::1 at 2025-04-01 14:56:05 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.9ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 1.5ms | GC: 0.0ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 4.6ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 10.1ms | GC: 0.8ms)
+Completed 200 OK in 14ms (Views: 9.7ms | ActiveRecord: 0.9ms (1 query, 0 cached) | GC: 0.8ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 14:56:06 +0100
+  
+ActionController::RoutingError (No route matches [GET] "/entries/1"):
+  
+Started GET "/entries/1" for ::1 at 2025-04-01 14:56:55 +0100
+  
+AbstractController::ActionNotFound (The action 'show' could not be found for EntriesController):
+  
+actionpack (7.2.2.1) lib/abstract_controller/base.rb:158:in `process'
+actionview (7.2.2.1) lib/action_view/rendering.rb:40:in `process'
+actionpack (7.2.2.1) lib/action_controller/metal.rb:252:in `dispatch'
+actionpack (7.2.2.1) lib/action_controller/metal.rb:335:in `dispatch'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:67:in `dispatch'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:50:in `serve'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:53:in `block in serve'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:133:in `block in find_routes'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `each'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `find_routes'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:34:in `serve'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:896:in `call'
+rack (3.1.12) lib/rack/tempfile_reaper.rb:20:in `call'
+rack (3.1.12) lib/rack/etag.rb:29:in `call'
+rack (3.1.12) lib/rack/conditional_get.rb:31:in `call'
+rack (3.1.12) lib/rack/head.rb:15:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/http/permissions_policy.rb:38:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/http/content_security_policy.rb:38:in `call'
+rack-session (2.1.0) lib/rack/session/abstract/id.rb:274:in `context'
+rack-session (2.1.0) lib/rack/session/abstract/id.rb:268:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/cookies.rb:704:in `call'
+activerecord (7.2.2.1) lib/active_record/migration.rb:674:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:31:in `block in call'
+activesupport (7.2.2.1) lib/active_support/callbacks.rb:101:in `run_callbacks'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:30:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/actionable_exceptions.rb:18:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:31:in `call'
+web-console (4.2.1) lib/web_console/middleware.rb:132:in `call_app'
+web-console (4.2.1) lib/web_console/middleware.rb:28:in `block in call'
+web-console (4.2.1) lib/web_console/middleware.rb:17:in `catch'
+web-console (4.2.1) lib/web_console/middleware.rb:17:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/show_exceptions.rb:32:in `call'
+railties (7.2.2.1) lib/rails/rack/logger.rb:41:in `call_app'
+railties (7.2.2.1) lib/rails/rack/logger.rb:29:in `call'
+sprockets-rails (3.5.2) lib/sprockets/rails/quiet_assets.rb:17:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/remote_ip.rb:96:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/request_id.rb:33:in `call'
+rack (3.1.12) lib/rack/method_override.rb:28:in `call'
+rack (3.1.12) lib/rack/runtime.rb:24:in `call'
+activesupport (7.2.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:61:in `block in call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:26:in `collect_events'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:60:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/static.rb:27:in `call'
+rack (3.1.12) lib/rack/sendfile.rb:114:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/host_authorization.rb:143:in `call'
+railties (7.2.2.1) lib/rails/engine.rb:535:in `call'
+puma (6.6.0) lib/puma/configuration.rb:279:in `call'
+puma (6.6.0) lib/puma/request.rb:99:in `block in handle_request'
+puma (6.6.0) lib/puma/thread_pool.rb:390:in `with_force_shutdown'
+puma (6.6.0) lib/puma/request.rb:98:in `handle_request'
+puma (6.6.0) lib/puma/server.rb:472:in `process_client'
+puma (6.6.0) lib/puma/server.rb:254:in `block in run'
+puma (6.6.0) lib/puma/thread_pool.rb:167:in `block in spawn_thread'
+Started GET "/entries/1" for ::1 at 2025-04-01 14:56:56 +0100
+  
+AbstractController::ActionNotFound (The action 'show' could not be found for EntriesController):
+  
+actionpack (7.2.2.1) lib/abstract_controller/base.rb:158:in `process'
+actionview (7.2.2.1) lib/action_view/rendering.rb:40:in `process'
+actionpack (7.2.2.1) lib/action_controller/metal.rb:252:in `dispatch'
+actionpack (7.2.2.1) lib/action_controller/metal.rb:335:in `dispatch'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:67:in `dispatch'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:50:in `serve'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:53:in `block in serve'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:133:in `block in find_routes'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `each'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `find_routes'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:34:in `serve'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:896:in `call'
+rack (3.1.12) lib/rack/tempfile_reaper.rb:20:in `call'
+rack (3.1.12) lib/rack/etag.rb:29:in `call'
+rack (3.1.12) lib/rack/conditional_get.rb:31:in `call'
+rack (3.1.12) lib/rack/head.rb:15:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/http/permissions_policy.rb:38:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/http/content_security_policy.rb:38:in `call'
+rack-session (2.1.0) lib/rack/session/abstract/id.rb:274:in `context'
+rack-session (2.1.0) lib/rack/session/abstract/id.rb:268:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/cookies.rb:704:in `call'
+activerecord (7.2.2.1) lib/active_record/migration.rb:674:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:31:in `block in call'
+activesupport (7.2.2.1) lib/active_support/callbacks.rb:101:in `run_callbacks'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:30:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/actionable_exceptions.rb:18:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:31:in `call'
+web-console (4.2.1) lib/web_console/middleware.rb:132:in `call_app'
+web-console (4.2.1) lib/web_console/middleware.rb:28:in `block in call'
+web-console (4.2.1) lib/web_console/middleware.rb:17:in `catch'
+web-console (4.2.1) lib/web_console/middleware.rb:17:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/show_exceptions.rb:32:in `call'
+railties (7.2.2.1) lib/rails/rack/logger.rb:41:in `call_app'
+railties (7.2.2.1) lib/rails/rack/logger.rb:29:in `call'
+sprockets-rails (3.5.2) lib/sprockets/rails/quiet_assets.rb:17:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/remote_ip.rb:96:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/request_id.rb:33:in `call'
+rack (3.1.12) lib/rack/method_override.rb:28:in `call'
+rack (3.1.12) lib/rack/runtime.rb:24:in `call'
+activesupport (7.2.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:61:in `block in call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:26:in `collect_events'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:60:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/static.rb:27:in `call'
+rack (3.1.12) lib/rack/sendfile.rb:114:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/host_authorization.rb:143:in `call'
+railties (7.2.2.1) lib/rails/engine.rb:535:in `call'
+puma (6.6.0) lib/puma/configuration.rb:279:in `call'
+puma (6.6.0) lib/puma/request.rb:99:in `block in handle_request'
+puma (6.6.0) lib/puma/thread_pool.rb:390:in `with_force_shutdown'
+puma (6.6.0) lib/puma/request.rb:98:in `handle_request'
+puma (6.6.0) lib/puma/server.rb:472:in `process_client'
+puma (6.6.0) lib/puma/server.rb:254:in `block in run'
+puma (6.6.0) lib/puma/thread_pool.rb:167:in `block in spawn_thread'
+Started GET "/entries/1" for ::1 at 2025-04-01 14:57:35 +0100
+  
+AbstractController::ActionNotFound (The action 'show' could not be found for EntriesController):
+  
+actionpack (7.2.2.1) lib/abstract_controller/base.rb:158:in `process'
+actionview (7.2.2.1) lib/action_view/rendering.rb:40:in `process'
+actionpack (7.2.2.1) lib/action_controller/metal.rb:252:in `dispatch'
+actionpack (7.2.2.1) lib/action_controller/metal.rb:335:in `dispatch'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:67:in `dispatch'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:50:in `serve'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:53:in `block in serve'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:133:in `block in find_routes'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `each'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `find_routes'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:34:in `serve'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:896:in `call'
+rack (3.1.12) lib/rack/tempfile_reaper.rb:20:in `call'
+rack (3.1.12) lib/rack/etag.rb:29:in `call'
+rack (3.1.12) lib/rack/conditional_get.rb:31:in `call'
+rack (3.1.12) lib/rack/head.rb:15:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/http/permissions_policy.rb:38:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/http/content_security_policy.rb:38:in `call'
+rack-session (2.1.0) lib/rack/session/abstract/id.rb:274:in `context'
+rack-session (2.1.0) lib/rack/session/abstract/id.rb:268:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/cookies.rb:704:in `call'
+activerecord (7.2.2.1) lib/active_record/migration.rb:674:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:31:in `block in call'
+activesupport (7.2.2.1) lib/active_support/callbacks.rb:101:in `run_callbacks'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:30:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/actionable_exceptions.rb:18:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:31:in `call'
+web-console (4.2.1) lib/web_console/middleware.rb:132:in `call_app'
+web-console (4.2.1) lib/web_console/middleware.rb:28:in `block in call'
+web-console (4.2.1) lib/web_console/middleware.rb:17:in `catch'
+web-console (4.2.1) lib/web_console/middleware.rb:17:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/show_exceptions.rb:32:in `call'
+railties (7.2.2.1) lib/rails/rack/logger.rb:41:in `call_app'
+railties (7.2.2.1) lib/rails/rack/logger.rb:29:in `call'
+sprockets-rails (3.5.2) lib/sprockets/rails/quiet_assets.rb:17:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/remote_ip.rb:96:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/request_id.rb:33:in `call'
+rack (3.1.12) lib/rack/method_override.rb:28:in `call'
+rack (3.1.12) lib/rack/runtime.rb:24:in `call'
+activesupport (7.2.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:61:in `block in call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:26:in `collect_events'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:60:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/static.rb:27:in `call'
+rack (3.1.12) lib/rack/sendfile.rb:114:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/host_authorization.rb:143:in `call'
+railties (7.2.2.1) lib/rails/engine.rb:535:in `call'
+puma (6.6.0) lib/puma/configuration.rb:279:in `call'
+puma (6.6.0) lib/puma/request.rb:99:in `block in handle_request'
+puma (6.6.0) lib/puma/thread_pool.rb:390:in `with_force_shutdown'
+puma (6.6.0) lib/puma/request.rb:98:in `handle_request'
+puma (6.6.0) lib/puma/server.rb:472:in `process_client'
+puma (6.6.0) lib/puma/server.rb:254:in `block in run'
+puma (6.6.0) lib/puma/thread_pool.rb:167:in `block in spawn_thread'
+Started GET "/entries/1" for ::1 at 2025-04-01 14:57:46 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:26:in `show'
+Completed 406 Not Acceptable in 8ms (ActiveRecord: 3.2ms (1 query, 0 cached) | GC: 0.2ms)
+
+
+  
+ActionController::MissingExactTemplate (EntriesController#show is missing a template for request formats: text/html):
+  
+actionpack (7.2.2.1) lib/action_controller/metal/implicit_render.rb:49:in `default_render'
+actionpack (7.2.2.1) lib/action_controller/metal/basic_implicit_render.rb:9:in `send_action'
+actionpack (7.2.2.1) lib/abstract_controller/base.rb:226:in `process_action'
+actionpack (7.2.2.1) lib/action_controller/metal/rendering.rb:193:in `process_action'
+actionpack (7.2.2.1) lib/abstract_controller/callbacks.rb:261:in `block in process_action'
+activesupport (7.2.2.1) lib/active_support/callbacks.rb:121:in `block in run_callbacks'
+turbo-rails (2.0.13) lib/turbo-rails.rb:24:in `with_request_id'
+turbo-rails (2.0.13) app/controllers/concerns/turbo/request_id_tracking.rb:10:in `turbo_tracking_request_id'
+activesupport (7.2.2.1) lib/active_support/callbacks.rb:130:in `block in run_callbacks'
+actiontext (7.2.2.1) lib/action_text/rendering.rb:25:in `with_renderer'
+actiontext (7.2.2.1) lib/action_text/engine.rb:71:in `block (4 levels) in <class:Engine>'
+activesupport (7.2.2.1) lib/active_support/callbacks.rb:130:in `instance_exec'
+activesupport (7.2.2.1) lib/active_support/callbacks.rb:130:in `block in run_callbacks'
+activesupport (7.2.2.1) lib/active_support/callbacks.rb:141:in `run_callbacks'
+actionpack (7.2.2.1) lib/abstract_controller/callbacks.rb:260:in `process_action'
+actionpack (7.2.2.1) lib/action_controller/metal/rescue.rb:27:in `process_action'
+actionpack (7.2.2.1) lib/action_controller/metal/instrumentation.rb:77:in `block in process_action'
+activesupport (7.2.2.1) lib/active_support/notifications.rb:210:in `block in instrument'
+activesupport (7.2.2.1) lib/active_support/notifications/instrumenter.rb:58:in `instrument'
+activesupport (7.2.2.1) lib/active_support/notifications.rb:210:in `instrument'
+actionpack (7.2.2.1) lib/action_controller/metal/instrumentation.rb:76:in `process_action'
+actionpack (7.2.2.1) lib/action_controller/metal/params_wrapper.rb:259:in `process_action'
+activerecord (7.2.2.1) lib/active_record/railties/controller_runtime.rb:39:in `process_action'
+actionpack (7.2.2.1) lib/abstract_controller/base.rb:163:in `process'
+actionview (7.2.2.1) lib/action_view/rendering.rb:40:in `process'
+actionpack (7.2.2.1) lib/action_controller/metal.rb:252:in `dispatch'
+actionpack (7.2.2.1) lib/action_controller/metal.rb:335:in `dispatch'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:67:in `dispatch'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:50:in `serve'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:53:in `block in serve'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:133:in `block in find_routes'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `each'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `find_routes'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:34:in `serve'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:896:in `call'
+rack (3.1.12) lib/rack/tempfile_reaper.rb:20:in `call'
+rack (3.1.12) lib/rack/etag.rb:29:in `call'
+rack (3.1.12) lib/rack/conditional_get.rb:31:in `call'
+rack (3.1.12) lib/rack/head.rb:15:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/http/permissions_policy.rb:38:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/http/content_security_policy.rb:38:in `call'
+rack-session (2.1.0) lib/rack/session/abstract/id.rb:274:in `context'
+rack-session (2.1.0) lib/rack/session/abstract/id.rb:268:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/cookies.rb:704:in `call'
+activerecord (7.2.2.1) lib/active_record/migration.rb:674:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:31:in `block in call'
+activesupport (7.2.2.1) lib/active_support/callbacks.rb:101:in `run_callbacks'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:30:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/actionable_exceptions.rb:18:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:31:in `call'
+web-console (4.2.1) lib/web_console/middleware.rb:132:in `call_app'
+web-console (4.2.1) lib/web_console/middleware.rb:28:in `block in call'
+web-console (4.2.1) lib/web_console/middleware.rb:17:in `catch'
+web-console (4.2.1) lib/web_console/middleware.rb:17:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/show_exceptions.rb:32:in `call'
+railties (7.2.2.1) lib/rails/rack/logger.rb:41:in `call_app'
+railties (7.2.2.1) lib/rails/rack/logger.rb:29:in `call'
+sprockets-rails (3.5.2) lib/sprockets/rails/quiet_assets.rb:17:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/remote_ip.rb:96:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/request_id.rb:33:in `call'
+rack (3.1.12) lib/rack/method_override.rb:28:in `call'
+rack (3.1.12) lib/rack/runtime.rb:24:in `call'
+activesupport (7.2.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:61:in `block in call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:26:in `collect_events'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:60:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/static.rb:27:in `call'
+rack (3.1.12) lib/rack/sendfile.rb:114:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/host_authorization.rb:143:in `call'
+railties (7.2.2.1) lib/rails/engine.rb:535:in `call'
+puma (6.6.0) lib/puma/configuration.rb:279:in `call'
+puma (6.6.0) lib/puma/request.rb:99:in `block in handle_request'
+puma (6.6.0) lib/puma/thread_pool.rb:390:in `with_force_shutdown'
+puma (6.6.0) lib/puma/request.rb:98:in `handle_request'
+puma (6.6.0) lib/puma/server.rb:472:in `process_client'
+puma (6.6.0) lib/puma/server.rb:254:in `block in run'
+puma (6.6.0) lib/puma/thread_pool.rb:167:in `block in spawn_thread'
+Started GET "/entries/1" for ::1 at 2025-04-01 14:58:10 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:26:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.2ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 8.9ms | GC: 0.9ms)
+Completed 200 OK in 19ms (Views: 9.6ms | ActiveRecord: 5.5ms (1 query, 0 cached) | GC: 1.2ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 14:58:29 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:26:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.2ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.2ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 9.9ms | GC: 1.2ms)
+Completed 200 OK in 18ms (Views: 10.5ms | ActiveRecord: 4.3ms (1 query, 0 cached) | GC: 1.5ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 14:58:29 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:26:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 2.2ms | GC: 0.0ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 12.4ms | GC: 0.7ms)
+Completed 200 OK in 17ms (Views: 12.9ms | ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 1.1ms)
+
+
+Started GET "/entries/new" for ::1 at 2025-04-01 14:58:29 +0100
+Processing by EntriesController#new as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/new.html.erb within layouts/application
+  Rendered entries/new.html.erb within layouts/application (Duration: 2.8ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 11.2ms | GC: 0.7ms)
+Completed 200 OK in 13ms (Views: 11.6ms | ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 0.7ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 14:58:30 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.6ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 2.5ms | GC: 0.2ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 6.7ms | GC: 0.4ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 16.1ms | GC: 0.8ms)
+Completed 200 OK in 18ms (Views: 16.0ms | ActiveRecord: 0.6ms (1 query, 0 cached) | GC: 0.8ms)
+
+
+Started GET "/entries/2" for ::1 at 2025-04-01 14:58:32 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"2"}
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:26:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 2.0ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.2ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 11.3ms | GC: 0.7ms)
+Completed 200 OK in 15ms (Views: 11.6ms | ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 0.9ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 14:58:33 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (1.0ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 2.1ms | GC: 0.0ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 5.6ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 14.5ms | GC: 0.6ms)
+Completed 200 OK in 16ms (Views: 14.0ms | ActiveRecord: 0.9ms (1 query, 0 cached) | GC: 0.6ms)
+
+
+Started GET "/entries/2" for ::1 at 2025-04-01 14:58:34 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"2"}
+  [1m[36mEntry Load (0.3ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:26:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 2.2ms | GC: 0.3ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 8.2ms | GC: 0.6ms)
+Completed 200 OK in 11ms (Views: 8.5ms | ActiveRecord: 0.3ms (1 query, 0 cached) | GC: 0.6ms)
+
+
+Started GET "/entries/new" for ::1 at 2025-04-01 14:58:36 +0100
+Processing by EntriesController#new as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/new.html.erb within layouts/application
+  Rendered entries/new.html.erb within layouts/application (Duration: 2.1ms | GC: 0.0ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.2ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 10.1ms | GC: 0.5ms)
+Completed 200 OK in 11ms (Views: 10.5ms | ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 0.5ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 14:58:36 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 1.7ms | GC: 0.0ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 4.3ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 12.2ms | GC: 0.5ms)
+Completed 200 OK in 14ms (Views: 12.3ms | ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 0.5ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 14:58:38 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.3ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:26:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 2.8ms | GC: 0.4ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 9.6ms | GC: 0.7ms)
+Completed 200 OK in 13ms (Views: 10.1ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.7ms)
+
+
+Started GET "/entries/new" for ::1 at 2025-04-01 14:58:48 +0100
+Processing by EntriesController#new as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/new.html.erb within layouts/application
+  Rendered entries/new.html.erb within layouts/application (Duration: 2.5ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 9.3ms | GC: 0.4ms)
+Completed 200 OK in 10ms (Views: 9.6ms | ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 0.4ms)
+
+
+Started GET "/entries/new" for ::1 at 2025-04-01 14:58:50 +0100
+Processing by EntriesController#new as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/new.html.erb within layouts/application
+  Rendered entries/new.html.erb within layouts/application (Duration: 7.8ms | GC: 0.0ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 12.2ms | GC: 0.4ms)
+Completed 200 OK in 14ms (Views: 12.7ms | ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 0.4ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 14:59:52 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.5ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 1.1ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 8.0ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.2ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 19.6ms | GC: 3.9ms)
+Completed 200 OK in 22ms (Views: 15.9ms | ActiveRecord: 4.4ms (1 query, 0 cached) | GC: 4.0ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 14:59:53 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.3ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:26:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 9.7ms | GC: 0.5ms)
+  Rendered layout layouts/application.html.erb (Duration: 10.0ms | GC: 0.5ms)
+Completed 500 Internal Server Error in 14ms (ActiveRecord: 0.3ms (1 query, 0 cached) | GC: 0.8ms)
+
+
+  
+ActionView::Template::Error (undefined local variable or method `entry' for #<ActionView::Base:0x0000000004e228>
+Did you mean?  @entry
+               retry):
+
+Causes:
+NameError (undefined local variable or method `entry' for #<ActionView::Base:0x0000000004e228>
+Did you mean?  @entry
+               retry)
+    2: 
+    3: <%= form_with(model: @entry) do |form| %>
+    4:   <div>
+    5:     <%= entry.name %>
+    6:     <%= form.label :name %>
+    7:     <%= form.text_field :name %>
+    8:     
+  
+app/views/entries/show.html.erb:5
+app/views/entries/show.html.erb:3
+Started GET "/entries/1" for ::1 at 2025-04-01 14:59:53 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:26:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 11.0ms | GC: 0.9ms)
+  Rendered layout layouts/application.html.erb (Duration: 11.3ms | GC: 0.9ms)
+Completed 500 Internal Server Error in 15ms (ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.9ms)
+
+
+  
+ActionView::Template::Error (undefined local variable or method `entry' for #<ActionView::Base:0x0000000004e4f8>
+Did you mean?  @entry
+               retry):
+
+Causes:
+NameError (undefined local variable or method `entry' for #<ActionView::Base:0x0000000004e4f8>
+Did you mean?  @entry
+               retry)
+    2: 
+    3: <%= form_with(model: @entry) do |form| %>
+    4:   <div>
+    5:     <%= entry.name %>
+    6:     <%= form.label :name %>
+    7:     <%= form.text_field :name %>
+    8:     
+  
+app/views/entries/show.html.erb:5
+app/views/entries/show.html.erb:3
+Started GET "/entries/1" for ::1 at 2025-04-01 15:00:07 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:26:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.2ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.2ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 9.0ms | GC: 0.9ms)
+Completed 200 OK in 21ms (Views: 9.9ms | ActiveRecord: 7.2ms (1 query, 0 cached) | GC: 1.4ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:00:12 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.6ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 4.8ms | GC: 0.3ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 8.9ms | GC: 0.3ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 18.2ms | GC: 0.8ms)
+Completed 200 OK in 22ms (Views: 18.4ms | ActiveRecord: 0.6ms (1 query, 0 cached) | GC: 1.2ms)
+
+
+Started GET "/entries/new" for ::1 at 2025-04-01 15:00:14 +0100
+Processing by EntriesController#new as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/new.html.erb within layouts/application
+  Rendered entries/new.html.erb within layouts/application (Duration: 2.3ms | GC: 0.0ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 8.8ms | GC: 0.7ms)
+Completed 200 OK in 19ms (Views: 9.2ms | ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 8.9ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 15:00:15 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:26:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 2.5ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 6.1ms | GC: 0.4ms)
+Completed 200 OK in 10ms (Views: 6.5ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.6ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 15:00:15 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.3ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:26:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 2.3ms | GC: 0.3ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 13.5ms | GC: 0.8ms)
+Completed 200 OK in 18ms (Views: 13.9ms | ActiveRecord: 0.3ms (1 query, 0 cached) | GC: 1.1ms)
+
+
+Started PATCH "/entries/1" for ::1 at 2025-04-01 15:00:21 +0100
+  
+ActionController::RoutingError (No route matches [PATCH] "/entries/1"):
+  
+Started GET "/entries/1" for ::1 at 2025-04-01 15:00:21 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.6ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:26:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.1ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 4.8ms | GC: 0.2ms)
+Completed 200 OK in 7ms (Views: 5.0ms | ActiveRecord: 0.6ms (1 query, 0 cached) | GC: 0.2ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:00:22 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (1.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 3.8ms | GC: 0.2ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 11.7ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.2ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 19.7ms | GC: 0.4ms)
+Completed 200 OK in 24ms (Views: 20.3ms | ActiveRecord: 1.2ms (1 query, 0 cached) | GC: 0.4ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 15:00:24 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.3ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:26:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.9ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 7.5ms | GC: 0.5ms)
+Completed 200 OK in 13ms (Views: 8.0ms | ActiveRecord: 0.3ms (1 query, 0 cached) | GC: 0.5ms)
+
+
+Started PATCH "/entries/1" for ::1 at 2025-04-01 15:00:28 +0100
+  
+ActionController::RoutingError (No route matches [PATCH] "/entries/1"):
+  
+Started GET "/entries/1" for ::1 at 2025-04-01 15:00:28 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:26:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 0.9ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.0ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 3.7ms | GC: 0.2ms)
+Completed 200 OK in 5ms (Views: 3.9ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.2ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:00:29 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.8ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 2.0ms | GC: 0.0ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 5.4ms | GC: 0.5ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 9.7ms | GC: 0.7ms)
+Completed 200 OK in 11ms (Views: 9.2ms | ActiveRecord: 0.8ms (1 query, 0 cached) | GC: 0.7ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:00:31 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 3.0ms | GC: 0.4ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 5.4ms | GC: 0.4ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 8.8ms | GC: 0.6ms)
+Completed 200 OK in 10ms (Views: 8.8ms | ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 1.0ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:00:31 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.5ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 2.8ms | GC: 0.4ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 5.7ms | GC: 0.4ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 13.8ms | GC: 1.0ms)
+Completed 200 OK in 15ms (Views: 13.6ms | ActiveRecord: 0.5ms (1 query, 0 cached) | GC: 1.0ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:00:31 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.5ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 3.0ms | GC: 0.4ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 6.0ms | GC: 0.4ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.7ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 15.3ms | GC: 0.8ms)
+Completed 200 OK in 17ms (Views: 15.2ms | ActiveRecord: 0.5ms (1 query, 0 cached) | GC: 0.8ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:00:31 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.5ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [4 times] (Duration: 2.6ms | GC: 0.0ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 6.3ms | GC: 0.3ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.2ms | GC: 0.1ms)
+  Rendered layout layouts/application.html.erb (Duration: 12.7ms | GC: 0.7ms)
+Completed 200 OK in 14ms (Views: 12.6ms | ActiveRecord: 0.5ms (1 query, 0 cached) | GC: 0.7ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 15:00:32 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:26:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 2.0ms | GC: 0.0ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 7.8ms | GC: 0.3ms)
+Completed 200 OK in 12ms (Views: 8.1ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.5ms)
+
+
+Started GET "/entries/2" for ::1 at 2025-04-01 15:00:32 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"2"}
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:26:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 3.5ms | GC: 0.0ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 10.7ms | GC: 0.8ms)
+Completed 200 OK in 17ms (Views: 11.3ms | ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 0.8ms)
+
+
+Started GET "/entries/4" for ::1 at 2025-04-01 15:00:33 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"4"}
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 4], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:26:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 3.8ms | GC: 0.4ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 10.3ms | GC: 0.9ms)
+Completed 200 OK in 17ms (Views: 11.0ms | ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 0.9ms)
+
+
+Started GET "/entries/5" for ::1 at 2025-04-01 15:00:34 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"5"}
+  [1m[36mEntry Load (0.3ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:26:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 2.5ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 12.2ms | GC: 0.8ms)
+Completed 200 OK in 16ms (Views: 12.6ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.8ms)
+
+
+Started GET "/entries/new" for ::1 at 2025-04-01 15:00:35 +0100
+Processing by EntriesController#new as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/new.html.erb within layouts/application
+  Rendered entries/new.html.erb within layouts/application (Duration: 3.2ms | GC: 0.0ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 7.9ms | GC: 0.3ms)
+Completed 200 OK in 10ms (Views: 8.4ms | ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 0.3ms)
+
+
+Started POST "/entries" for ::1 at 2025-04-01 15:00:46 +0100
+Processing by EntriesController#create as TURBO_STREAM
+  Parameters: {"authenticity_token"=>"[FILTERED]", "entry"=>{"name"=>"Name-1", "link"=>"Link-1"}, "commit"=>"Create Entry"}
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/entries_controller.rb:13:in `create'
+  [1m[36mEntry Create (1.9ms)[0m  [1m[32mINSERT INTO "entries" ("name", "created_at", "updated_at", "link") VALUES ($1, $2, $3, $4) RETURNING "id"[0m  [["name", "Name-1"], ["created_at", "2025-04-01 14:00:46.586873"], ["updated_at", "2025-04-01 14:00:46.586873"], ["link", "Link-1"]]
+  ↳ app/controllers/entries_controller.rb:13:in `create'
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/entries_controller.rb:13:in `create'
+Redirected to http://localhost:3000/
+Completed 302 Found in 9ms (ActiveRecord: 3.4ms (1 query, 0 cached) | GC: 0.3ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:00:46 +0100
+Processing by EntriesController#index as TURBO_STREAM
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 2.3ms | GC: 0.2ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 4.1ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 11.0ms | GC: 0.5ms)
+Completed 200 OK in 12ms (Views: 10.9ms | ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 0.5ms)
+
+
+Started GET "/entries/new" for ::1 at 2025-04-01 15:00:46 +0100
+Processing by EntriesController#new as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/new.html.erb within layouts/application
+  Rendered entries/new.html.erb within layouts/application (Duration: 2.4ms | GC: 0.3ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 9.9ms | GC: 0.8ms)
+Completed 200 OK in 12ms (Views: 10.3ms | ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 0.8ms)
+
+
+Started GET "/entries/6" for ::1 at 2025-04-01 15:00:47 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"6"}
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:26:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 2.4ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 8.5ms | GC: 0.7ms)
+Completed 200 OK in 14ms (Views: 8.9ms | ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 0.7ms)
+
+
+Started GET "/entries/6" for ::1 at 2025-04-01 15:01:04 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"6"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:26:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.3ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.2ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 13.1ms | GC: 4.0ms)
+Completed 200 OK in 22ms (Views: 13.8ms | ActiveRecord: 4.4ms (1 query, 0 cached) | GC: 4.4ms)
+
+
+Started GET "/entries/6" for ::1 at 2025-04-01 15:01:04 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"6"}
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:26:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 6.5ms | GC: 0.5ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 12.1ms | GC: 0.9ms)
+Completed 200 OK in 20ms (Views: 12.7ms | ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 1.5ms)
+
+
+Started GET "/entries/6" for ::1 at 2025-04-01 15:02:17 +0100
+  
+ActionController::RoutingError (No route matches [GET] "/entries/6"):
+  
+Started GET "/entries/6" for ::1 at 2025-04-01 15:02:18 +0100
+  
+ActionController::RoutingError (No route matches [GET] "/entries/6"):
+  
+Started GET "/entries/6" for ::1 at 2025-04-01 15:03:10 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"6"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 2.0ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.3ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 11.4ms | GC: 1.0ms)
+Completed 200 OK in 42ms (Views: 12.9ms | ActiveRecord: 23.5ms (1 query, 0 cached) | GC: 1.5ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:03:12 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 4.9ms | GC: 0.2ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 8.5ms | GC: 0.6ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 12.9ms | GC: 0.8ms)
+Completed 200 OK in 14ms (Views: 12.8ms | ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 0.8ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 15:03:15 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.8ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 10.2ms | GC: 0.5ms)
+Completed 200 OK in 13ms (Views: 10.6ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.7ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:03:17 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.6ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 3.5ms | GC: 0.2ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 6.6ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 15.1ms | GC: 1.0ms)
+Completed 200 OK in 17ms (Views: 15.2ms | ActiveRecord: 0.5ms (1 query, 0 cached) | GC: 1.2ms)
+
+
+Started GET "/entries/6" for ::1 at 2025-04-01 15:03:24 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"6"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 2.1ms | GC: 0.4ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 9.8ms | GC: 0.8ms)
+Completed 200 OK in 13ms (Views: 10.1ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.8ms)
+
+
+Started PATCH "/entries/6" for ::1 at 2025-04-01 15:03:30 +0100
+  
+ActionController::RoutingError (No route matches [PATCH] "/entries/6"):
+  
+Started GET "/entries/6" for ::1 at 2025-04-01 15:03:30 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"6"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.0ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.0ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 4.5ms | GC: 0.3ms)
+Completed 200 OK in 6ms (Views: 4.7ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.5ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:03:31 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.6ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 2.5ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 5.2ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 12.1ms | GC: 0.4ms)
+Completed 200 OK in 13ms (Views: 11.8ms | ActiveRecord: 0.6ms (1 query, 0 cached) | GC: 0.6ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:04:05 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 1.2ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 8.8ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 16.3ms | GC: 0.8ms)
+Completed 200 OK in 18ms (Views: 11.7ms | ActiveRecord: 5.2ms (1 query, 0 cached) | GC: 0.9ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 15:04:06 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 3.9ms | GC: 0.4ms)
+  Rendered layout layouts/application.html.erb (Duration: 4.2ms | GC: 0.4ms)
+Completed 500 Internal Server Error in 8ms (ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.4ms)
+
+
+  
+ActionView::Template::Error (undefined method `update' for #<ActionView::Helpers::FormBuilder:0x000000011892ce58 @nested_child_index={}, @options={:allow_method_names_outside_object=>true, :skip_default_ids=>false}, @template=#<ActionView::Base:0x00000000062228>, @object=#<Entry id: 1, name: "test", created_at: "2025-03-31 15:11:48.002542000 +0000", updated_at: "2025-03-31 15:11:48.002542000 +0000", link: nil>, @object_name="entry", @default_options={:skip_default_ids=>false, :allow_method_names_outside_object=>true}, @default_html_options={}, @multipart=nil, @index=nil>):
+
+Causes:
+NoMethodError (undefined method `update' for #<ActionView::Helpers::FormBuilder:0x000000011892ce58 @nested_child_index={}, @options={:allow_method_names_outside_object=>true, :skip_default_ids=>false}, @template=#<ActionView::Base:0x00000000062228>, @object=#<Entry id: 1, name: "test", created_at: "2025-03-31 15:11:48.002542000 +0000", updated_at: "2025-03-31 15:11:48.002542000 +0000", link: nil>, @object_name="entry", @default_options={:skip_default_ids=>false, :allow_method_names_outside_object=>true}, @default_html_options={}, @multipart=nil, @index=nil>)
+    12:   </div>
+    13:   
+    14:   <div>
+    15:     <%= form.update "Update Entry" %>
+    16:   </div>
+    17: <% end %>
+    18: 
+  
+app/views/entries/show.html.erb:15
+app/views/entries/show.html.erb:3
+Started GET "/" for ::1 at 2025-04-01 15:04:09 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.5ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 3.6ms | GC: 0.4ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 6.6ms | GC: 0.4ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 13.3ms | GC: 0.8ms)
+Completed 200 OK in 15ms (Views: 13.2ms | ActiveRecord: 0.5ms (1 query, 0 cached) | GC: 0.8ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:05:25 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 1.1ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 6.4ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 16.5ms | GC: 3.4ms)
+Completed 200 OK in 18ms (Views: 14.0ms | ActiveRecord: 3.2ms (1 query, 0 cached) | GC: 3.5ms)
+
+
+Started GET "/entries/new" for ::1 at 2025-04-01 15:05:26 +0100
+Processing by EntriesController#new as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/new.html.erb within layouts/application
+  Rendered entries/new.html.erb within layouts/application (Duration: 2.5ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 7.5ms | GC: 0.4ms)
+Completed 200 OK in 10ms (Views: 8.0ms | ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 0.4ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 15:05:26 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 5.8ms | GC: 0.0ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 14.9ms | GC: 0.5ms)
+Completed 200 OK in 20ms (Views: 15.9ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.8ms)
+
+
+Started GET "/entries/6" for ::1 at 2025-04-01 15:05:27 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"6"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.7ms | GC: 0.0ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 6.6ms | GC: 0.4ms)
+Completed 200 OK in 10ms (Views: 7.1ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.6ms)
+
+
+Started PATCH "/entries/6" for ::1 at 2025-04-01 15:05:31 +0100
+  
+ActionController::RoutingError (No route matches [PATCH] "/entries/6"):
+  
+Started GET "/entries/6" for ::1 at 2025-04-01 15:05:32 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"6"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.0ms | GC: 0.0ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.0ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 4.8ms | GC: 0.2ms)
+Completed 200 OK in 7ms (Views: 5.2ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.3ms)
+
+
+Started GET "/entries/new" for ::1 at 2025-04-01 15:05:32 +0100
+Processing by EntriesController#new as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/new.html.erb within layouts/application
+  Rendered entries/new.html.erb within layouts/application (Duration: 1.8ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 6.2ms | GC: 0.3ms)
+Completed 200 OK in 8ms (Views: 6.6ms | ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 0.3ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:05:33 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.5ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 2.5ms | GC: 0.2ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 7.2ms | GC: 0.5ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 17.1ms | GC: 0.8ms)
+Completed 200 OK in 18ms (Views: 17.0ms | ActiveRecord: 0.5ms (1 query, 0 cached) | GC: 0.8ms)
+
+
+Started GET "/entries/6" for ::1 at 2025-04-01 15:05:34 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"6"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.8ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 8.8ms | GC: 0.5ms)
+Completed 200 OK in 12ms (Views: 9.1ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.6ms)
+
+
+Started GET "/entries" for ::1 at 2025-04-01 15:05:35 +0100
+  
+ActionController::RoutingError (No route matches [GET] "/entries"):
+  
+Started GET "/entries/6" for ::1 at 2025-04-01 15:05:40 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"6"}
+  [1m[36mEntry Load (0.3ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 2.8ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 11.2ms | GC: 0.6ms)
+Completed 200 OK in 15ms (Views: 11.6ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.6ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:05:40 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (1.0ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 2.4ms | GC: 0.2ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 5.6ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.2ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 14.4ms | GC: 0.6ms)
+Completed 200 OK in 17ms (Views: 14.1ms | ActiveRecord: 0.9ms (1 query, 0 cached) | GC: 0.6ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:05:42 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (1.0ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 5.3ms | GC: 0.0ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 12.4ms | GC: 1.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 19.7ms | GC: 2.3ms)
+Completed 200 OK in 22ms (Views: 19.4ms | ActiveRecord: 1.0ms (1 query, 0 cached) | GC: 2.3ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:05:43 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (2.7ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 2.3ms | GC: 0.2ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 7.7ms | GC: 0.5ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 13.7ms | GC: 0.9ms)
+Completed 200 OK in 18ms (Views: 11.7ms | ActiveRecord: 2.7ms (1 query, 0 cached) | GC: 0.9ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:05:43 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (1.0ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 2.0ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 4.7ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 10.0ms | GC: 0.4ms)
+Completed 200 OK in 13ms (Views: 9.5ms | ActiveRecord: 1.0ms (1 query, 0 cached) | GC: 0.8ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:05:43 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.8ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 1.8ms | GC: 0.2ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 5.0ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 11.2ms | GC: 0.7ms)
+Completed 200 OK in 13ms (Views: 11.0ms | ActiveRecord: 0.8ms (1 query, 0 cached) | GC: 0.7ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:05:43 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (3.3ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 5.1ms | GC: 0.5ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 12.6ms | GC: 0.9ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 19.4ms | GC: 1.3ms)
+Completed 200 OK in 22ms (Views: 16.7ms | ActiveRecord: 3.2ms (1 query, 0 cached) | GC: 1.3ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:05:43 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (1.1ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 2.0ms | GC: 0.2ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 4.6ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 10.3ms | GC: 0.5ms)
+Completed 200 OK in 14ms (Views: 11.1ms | ActiveRecord: 1.1ms (1 query, 0 cached) | GC: 1.0ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:05:43 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.9ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 2.3ms | GC: 0.3ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 5.4ms | GC: 0.7ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 11.4ms | GC: 1.2ms)
+Completed 200 OK in 13ms (Views: 10.9ms | ActiveRecord: 0.9ms (1 query, 0 cached) | GC: 1.2ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:05:44 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.7ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 2.1ms | GC: 0.2ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 4.0ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 9.3ms | GC: 0.7ms)
+Completed 200 OK in 12ms (Views: 9.3ms | ActiveRecord: 0.7ms (1 query, 0 cached) | GC: 0.9ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:05:44 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (1.0ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 5.9ms | GC: 0.4ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 10.1ms | GC: 0.4ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 15.7ms | GC: 0.8ms)
+Completed 200 OK in 19ms (Views: 16.2ms | ActiveRecord: 0.9ms (1 query, 0 cached) | GC: 0.8ms)
+
+
+Started GET "/entries/6" for ::1 at 2025-04-01 15:05:45 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"6"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 2.1ms | GC: 0.0ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 8.1ms | GC: 0.3ms)
+Completed 200 OK in 12ms (Views: 8.5ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.6ms)
+
+
+Started GET "/entries/new" for ::1 at 2025-04-01 15:05:50 +0100
+Processing by EntriesController#new as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/new.html.erb within layouts/application
+  Rendered entries/new.html.erb within layouts/application (Duration: 2.9ms | GC: 0.3ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 14.0ms | GC: 1.0ms)
+Completed 200 OK in 16ms (Views: 14.4ms | ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 1.0ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:05:50 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.6ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 2.4ms | GC: 0.0ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 6.6ms | GC: 0.4ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 16.9ms | GC: 1.8ms)
+Completed 200 OK in 18ms (Views: 16.8ms | ActiveRecord: 0.6ms (1 query, 0 cached) | GC: 1.8ms)
+
+
+Started PATCH "/entries/6" for ::1 at 2025-04-01 15:05:51 +0100
+  
+ActionController::RoutingError (No route matches [PATCH] "/entries/6"):
+  
+Started GET "/entries/6" for ::1 at 2025-04-01 15:05:51 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"6"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.1ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.0ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 4.7ms | GC: 0.3ms)
+Completed 200 OK in 7ms (Views: 4.9ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.3ms)
+
+
+Started GET "/entries/new" for ::1 at 2025-04-01 15:05:52 +0100
+Processing by EntriesController#new as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/new.html.erb within layouts/application
+  Rendered entries/new.html.erb within layouts/application (Duration: 2.2ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 11.2ms | GC: 0.6ms)
+Completed 200 OK in 13ms (Views: 11.6ms | ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 0.6ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:05:52 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.6ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 2.7ms | GC: 0.3ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 6.4ms | GC: 0.7ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 11.1ms | GC: 1.0ms)
+Completed 200 OK in 12ms (Views: 10.9ms | ActiveRecord: 0.5ms (1 query, 0 cached) | GC: 1.0ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:06:37 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.9ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 1.2ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 7.6ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.2ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 15.5ms | GC: 1.0ms)
+Completed 200 OK in 18ms (Views: 12.2ms | ActiveRecord: 4.1ms (1 query, 0 cached) | GC: 1.1ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 15:06:39 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 2.7ms | GC: 0.0ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 7.4ms | GC: 0.4ms)
+Completed 200 OK in 12ms (Views: 7.7ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.6ms)
+
+
+Started GET "/entries/6" for ::1 at 2025-04-01 15:06:39 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"6"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.9ms | GC: 0.0ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 6.2ms | GC: 0.4ms)
+Completed 200 OK in 9ms (Views: 6.6ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.6ms)
+
+
+Started PATCH "/entries/6" for ::1 at 2025-04-01 15:06:44 +0100
+  
+ActionController::RoutingError (No route matches [PATCH] "/entries/6"):
+  
+Started GET "/entries/6" for ::1 at 2025-04-01 15:06:44 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"6"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.1ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.0ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 4.6ms | GC: 0.3ms)
+Completed 200 OK in 6ms (Views: 4.8ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.4ms)
+
+
+Started GET "/entries/new" for ::1 at 2025-04-01 15:06:45 +0100
+Processing by EntriesController#new as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/new.html.erb within layouts/application
+  Rendered entries/new.html.erb within layouts/application (Duration: 2.6ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 7.6ms | GC: 0.3ms)
+Completed 200 OK in 9ms (Views: 8.0ms | ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 0.3ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:06:45 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.6ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 3.2ms | GC: 0.3ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 6.4ms | GC: 0.3ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 15.7ms | GC: 0.8ms)
+Completed 200 OK in 17ms (Views: 15.5ms | ActiveRecord: 0.6ms (1 query, 0 cached) | GC: 0.8ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:06:48 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.6ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 2.5ms | GC: 0.0ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 5.5ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 12.8ms | GC: 0.6ms)
+Completed 200 OK in 15ms (Views: 12.6ms | ActiveRecord: 0.5ms (1 query, 0 cached) | GC: 0.6ms)
+
+
+Started GET "/entries/6" for ::1 at 2025-04-01 15:06:53 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"6"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.2ms | GC: 0.0ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 5.6ms | GC: 0.1ms)
+Completed 200 OK in 9ms (Views: 6.1ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.3ms)
+
+
+Started PATCH "/entries/6" for ::1 at 2025-04-01 15:06:59 +0100
+  
+ActionController::RoutingError (No route matches [PATCH] "/entries/6"):
+  
+Started GET "/entries/6" for ::1 at 2025-04-01 15:06:59 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"6"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.0ms | GC: 0.0ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.0ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 5.1ms | GC: 0.6ms)
+Completed 200 OK in 7ms (Views: 5.4ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.8ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:07:06 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 2.5ms | GC: 0.3ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 5.5ms | GC: 0.6ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 12.9ms | GC: 1.1ms)
+Completed 200 OK in 14ms (Views: 12.7ms | ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 1.1ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 15:07:08 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 2.1ms | GC: 0.3ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 6.3ms | GC: 0.5ms)
+Completed 200 OK in 10ms (Views: 6.6ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.5ms)
+
+
+Started PATCH "/entries/1" for ::1 at 2025-04-01 15:07:18 +0100
+  
+ActionController::RoutingError (No route matches [PATCH] "/entries/1"):
+  
+Started GET "/entries/1" for ::1 at 2025-04-01 15:07:18 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.0ms | GC: 0.0ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.0ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 4.5ms | GC: 0.2ms)
+Completed 200 OK in 7ms (Views: 4.8ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.3ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 15:10:00 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.1ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.1ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 9.0ms | GC: 1.0ms)
+Completed 200 OK in 17ms (Views: 9.8ms | ActiveRecord: 3.4ms (1 query, 0 cached) | GC: 1.3ms)
+
+
+Started PATCH "/entries/1" for ::1 at 2025-04-01 15:10:04 +0100
+Processing by EntriesController#update as TURBO_STREAM
+  Parameters: {"authenticity_token"=>"[FILTERED]", "entry"=>{"name"=>"test", "link"=>"test"}, "commit"=>"Update Entry", "id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:31:in `update'
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/entries_controller.rb:32:in `update'
+  [1m[36mEntry Update (1.9ms)[0m  [1m[33mUPDATE "entries" SET "updated_at" = $1, "link" = $2 WHERE "entries"."id" = $3[0m  [["updated_at", "2025-04-01 14:10:04.633779"], ["link", "test"], ["id", 1]]
+  ↳ app/controllers/entries_controller.rb:32:in `update'
+  [1m[36mTRANSACTION (0.5ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/entries_controller.rb:32:in `update'
+Redirected to http://localhost:3000/entries/1
+Completed 302 Found in 11ms (ActiveRecord: 2.6ms (2 queries, 0 cached) | GC: 0.7ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 15:10:04 +0100
+Processing by EntriesController#show as TURBO_STREAM
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.1ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 4.6ms | GC: 0.3ms)
+Completed 200 OK in 6ms (Views: 4.8ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.3ms)
+
+
+Started PATCH "/entries/1" for ::1 at 2025-04-01 15:10:05 +0100
+Processing by EntriesController#update as TURBO_STREAM
+  Parameters: {"authenticity_token"=>"[FILTERED]", "entry"=>{"name"=>"test", "link"=>"test"}, "commit"=>"Update Entry", "id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:31:in `update'
+Redirected to http://localhost:3000/entries/1
+Completed 302 Found in 5ms (ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.0ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 15:10:05 +0100
+Processing by EntriesController#show as TURBO_STREAM
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 0.9ms | GC: 0.0ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 4.7ms | GC: 0.2ms)
+Completed 200 OK in 7ms (Views: 5.0ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.3ms)
+
+
+Started PATCH "/entries/1" for ::1 at 2025-04-01 15:10:05 +0100
+Processing by EntriesController#update as TURBO_STREAM
+  Parameters: {"authenticity_token"=>"[FILTERED]", "entry"=>{"name"=>"test", "link"=>"test"}, "commit"=>"Update Entry", "id"=>"1"}
+  [1m[36mEntry Load (0.3ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:31:in `update'
+Redirected to http://localhost:3000/entries/1
+Completed 302 Found in 6ms (ActiveRecord: 0.3ms (1 query, 0 cached) | GC: 0.2ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 15:10:06 +0100
+Processing by EntriesController#show as TURBO_STREAM
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.0ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 10.6ms | GC: 0.4ms)
+Completed 200 OK in 13ms (Views: 10.8ms | ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 0.5ms)
+
+
+Started PATCH "/entries/1" for ::1 at 2025-04-01 15:10:06 +0100
+Processing by EntriesController#update as TURBO_STREAM
+  Parameters: {"authenticity_token"=>"[FILTERED]", "entry"=>{"name"=>"test", "link"=>"test"}, "commit"=>"Update Entry", "id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:31:in `update'
+Redirected to http://localhost:3000/entries/1
+Completed 302 Found in 5ms (ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.0ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 15:10:06 +0100
+Processing by EntriesController#show as TURBO_STREAM
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.1ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 0.9ms | GC: 0.0ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.0ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 4.3ms | GC: 0.3ms)
+Completed 200 OK in 6ms (Views: 4.5ms | ActiveRecord: 0.1ms (1 query, 0 cached) | GC: 0.5ms)
+
+
+Started PATCH "/entries/1" for ::1 at 2025-04-01 15:10:06 +0100
+Processing by EntriesController#update as TURBO_STREAM
+  Parameters: {"authenticity_token"=>"[FILTERED]", "entry"=>{"name"=>"test", "link"=>"test"}, "commit"=>"Update Entry", "id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:31:in `update'
+Redirected to http://localhost:3000/entries/1
+Completed 302 Found in 5ms (ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.2ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 15:10:06 +0100
+Processing by EntriesController#show as TURBO_STREAM
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.0ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 3.9ms | GC: 0.2ms)
+Completed 200 OK in 7ms (Views: 4.1ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.2ms)
+
+
+Started PATCH "/entries/1" for ::1 at 2025-04-01 15:10:06 +0100
+Processing by EntriesController#update as TURBO_STREAM
+  Parameters: {"authenticity_token"=>"[FILTERED]", "entry"=>{"name"=>"test", "link"=>"test"}, "commit"=>"Update Entry", "id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:31:in `update'
+Redirected to http://localhost:3000/entries/1
+Completed 302 Found in 7ms (ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.4ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 15:10:06 +0100
+Processing by EntriesController#show as TURBO_STREAM
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.0ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 4.3ms | GC: 0.2ms)
+Completed 200 OK in 7ms (Views: 4.5ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.5ms)
+
+
+Started PATCH "/entries/1" for ::1 at 2025-04-01 15:10:06 +0100
+Processing by EntriesController#update as TURBO_STREAM
+  Parameters: {"authenticity_token"=>"[FILTERED]", "entry"=>{"name"=>"test", "link"=>"test"}, "commit"=>"Update Entry", "id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:31:in `update'
+Redirected to http://localhost:3000/entries/1
+Completed 302 Found in 5ms (ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.0ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 15:10:06 +0100
+Processing by EntriesController#show as TURBO_STREAM
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.1ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 0.8ms | GC: 0.0ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 9.1ms | GC: 4.5ms)
+Completed 200 OK in 11ms (Views: 9.3ms | ActiveRecord: 0.1ms (1 query, 0 cached) | GC: 4.6ms)
+
+
+Started GET "/entries/new" for ::1 at 2025-04-01 15:10:07 +0100
+Processing by EntriesController#new as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/new.html.erb within layouts/application
+  Rendered entries/new.html.erb within layouts/application (Duration: 2.9ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 10.7ms | GC: 0.6ms)
+Completed 200 OK in 13ms (Views: 11.1ms | ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 0.6ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:10:07 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 2.7ms | GC: 0.3ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 6.0ms | GC: 0.3ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 15.1ms | GC: 1.0ms)
+Completed 200 OK in 17ms (Views: 15.0ms | ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 1.0ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 15:10:09 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.9ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 10.2ms | GC: 0.6ms)
+Completed 200 OK in 14ms (Views: 10.6ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.8ms)
+
+
+Started PATCH "/entries/1" for ::1 at 2025-04-01 15:10:16 +0100
+Processing by EntriesController#update as TURBO_STREAM
+  Parameters: {"authenticity_token"=>"[FILTERED]", "entry"=>{"name"=>"updated", "link"=>"updated"}, "commit"=>"Update Entry", "id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:31:in `update'
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/entries_controller.rb:32:in `update'
+  [1m[36mEntry Update (2.0ms)[0m  [1m[33mUPDATE "entries" SET "name" = $1, "updated_at" = $2, "link" = $3 WHERE "entries"."id" = $4[0m  [["name", "updated"], ["updated_at", "2025-04-01 14:10:16.180072"], ["link", "updated"], ["id", 1]]
+  ↳ app/controllers/entries_controller.rb:32:in `update'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/entries_controller.rb:32:in `update'
+Redirected to http://localhost:3000/entries/1
+Completed 302 Found in 8ms (ActiveRecord: 2.5ms (2 queries, 0 cached) | GC: 0.4ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 15:10:16 +0100
+Processing by EntriesController#show as TURBO_STREAM
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.1ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 0.9ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.0ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 4.2ms | GC: 0.3ms)
+Completed 200 OK in 5ms (Views: 4.3ms | ActiveRecord: 0.1ms (1 query, 0 cached) | GC: 0.3ms)
+
+
+Started GET "/entries/new" for ::1 at 2025-04-01 15:10:16 +0100
+Processing by EntriesController#new as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/new.html.erb within layouts/application
+  Rendered entries/new.html.erb within layouts/application (Duration: 3.1ms | GC: 0.3ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 8.9ms | GC: 0.6ms)
+Completed 200 OK in 10ms (Views: 9.3ms | ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 0.6ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:10:17 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 2.5ms | GC: 0.2ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 4.7ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 11.3ms | GC: 0.6ms)
+Completed 200 OK in 12ms (Views: 11.1ms | ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 0.6ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 15:10:18 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.3ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 2.6ms | GC: 0.3ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 9.2ms | GC: 0.7ms)
+Completed 200 OK in 13ms (Views: 9.7ms | ActiveRecord: 0.3ms (1 query, 0 cached) | GC: 0.7ms)
+
+
+Started PATCH "/entries/1" for ::1 at 2025-04-01 15:10:25 +0100
+Processing by EntriesController#update as TURBO_STREAM
+  Parameters: {"authenticity_token"=>"[FILTERED]", "entry"=>{"name"=>"updated-1", "link"=>"updated-1"}, "commit"=>"Update Entry", "id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:31:in `update'
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/entries_controller.rb:32:in `update'
+  [1m[36mEntry Update (1.6ms)[0m  [1m[33mUPDATE "entries" SET "name" = $1, "updated_at" = $2, "link" = $3 WHERE "entries"."id" = $4[0m  [["name", "updated-1"], ["updated_at", "2025-04-01 14:10:25.619601"], ["link", "updated-1"], ["id", 1]]
+  ↳ app/controllers/entries_controller.rb:32:in `update'
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/entries_controller.rb:32:in `update'
+Redirected to http://localhost:3000/entries/1
+Completed 302 Found in 10ms (ActiveRecord: 2.2ms (2 queries, 0 cached) | GC: 0.5ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 15:10:25 +0100
+Processing by EntriesController#show as TURBO_STREAM
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.1ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.0ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.0ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 4.3ms | GC: 0.3ms)
+Completed 200 OK in 6ms (Views: 4.5ms | ActiveRecord: 0.1ms (1 query, 0 cached) | GC: 0.4ms)
+
+
+Started GET "/entries/new" for ::1 at 2025-04-01 15:10:27 +0100
+Processing by EntriesController#new as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/new.html.erb within layouts/application
+  Rendered entries/new.html.erb within layouts/application (Duration: 2.5ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 11.2ms | GC: 0.7ms)
+Completed 200 OK in 13ms (Views: 11.6ms | ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 0.7ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:10:27 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.5ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 2.8ms | GC: 0.2ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 5.2ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 14.8ms | GC: 0.7ms)
+Completed 200 OK in 17ms (Views: 15.0ms | ActiveRecord: 0.5ms (1 query, 0 cached) | GC: 0.9ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:11:14 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.5ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 1.7ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 8.2ms | GC: 0.3ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.2ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 16.4ms | GC: 1.1ms)
+Completed 200 OK in 18ms (Views: 12.9ms | ActiveRecord: 4.1ms (1 query, 0 cached) | GC: 1.2ms)
+
+
+Started PATCH "/entries/2" for ::1 at 2025-04-01 15:11:15 +0100
+Processing by EntriesController#update as TURBO_STREAM
+  Parameters: {"authenticity_token"=>"[FILTERED]", "id"=>"2"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:31:in `update'
+Completed 400 Bad Request in 5ms (ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.3ms)
+
+
+  
+ActionController::ParameterMissing (param is missing or the value is empty: entry):
+  
+app/controllers/entries_controller.rb:42:in `entry_params'
+app/controllers/entries_controller.rb:32:in `update'
+Started GET "/" for ::1 at 2025-04-01 15:11:15 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.5ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 1.3ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 2.7ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.0ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 5.5ms | GC: 0.3ms)
+Completed 200 OK in 6ms (Views: 5.3ms | ActiveRecord: 0.5ms (1 query, 0 cached) | GC: 0.4ms)
+
+
+Started PATCH "/entries/2" for ::1 at 2025-04-01 15:11:16 +0100
+Processing by EntriesController#update as TURBO_STREAM
+  Parameters: {"authenticity_token"=>"[FILTERED]", "id"=>"2"}
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:31:in `update'
+Completed 400 Bad Request in 6ms (ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 0.3ms)
+
+
+  
+ActionController::ParameterMissing (param is missing or the value is empty: entry):
+  
+app/controllers/entries_controller.rb:42:in `entry_params'
+app/controllers/entries_controller.rb:32:in `update'
+Started GET "/" for ::1 at 2025-04-01 15:11:16 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (1.0ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 1.2ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 3.2ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.0ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 6.1ms | GC: 0.4ms)
+Completed 200 OK in 7ms (Views: 5.3ms | ActiveRecord: 1.0ms (1 query, 0 cached) | GC: 0.4ms)
+
+
+Started PATCH "/entries/2" for ::1 at 2025-04-01 15:11:16 +0100
+Processing by EntriesController#update as TURBO_STREAM
+  Parameters: {"authenticity_token"=>"[FILTERED]", "id"=>"2"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:31:in `update'
+Completed 400 Bad Request in 2ms (ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.1ms)
+
+
+  
+ActionController::ParameterMissing (param is missing or the value is empty: entry):
+  
+app/controllers/entries_controller.rb:42:in `entry_params'
+app/controllers/entries_controller.rb:32:in `update'
+Started GET "/" for ::1 at 2025-04-01 15:11:16 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 1.2ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 2.4ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.0ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 5.2ms | GC: 0.3ms)
+Completed 200 OK in 6ms (Views: 5.0ms | ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 0.4ms)
+
+
+Started PATCH "/entries/2" for ::1 at 2025-04-01 15:11:17 +0100
+Processing by EntriesController#update as TURBO_STREAM
+  Parameters: {"authenticity_token"=>"[FILTERED]", "id"=>"2"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:31:in `update'
+Completed 400 Bad Request in 5ms (ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.3ms)
+
+
+  
+ActionController::ParameterMissing (param is missing or the value is empty: entry):
+  
+app/controllers/entries_controller.rb:42:in `entry_params'
+app/controllers/entries_controller.rb:32:in `update'
+Started GET "/" for ::1 at 2025-04-01 15:11:17 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 1.3ms | GC: 0.3ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 2.6ms | GC: 0.3ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.0ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 5.4ms | GC: 0.5ms)
+Completed 200 OK in 6ms (Views: 5.2ms | ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 0.5ms)
+
+
+Started PATCH "/entries/1" for ::1 at 2025-04-01 15:11:18 +0100
+Processing by EntriesController#update as TURBO_STREAM
+  Parameters: {"authenticity_token"=>"[FILTERED]", "id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:31:in `update'
+Completed 400 Bad Request in 5ms (ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.8ms)
+
+
+  
+ActionController::ParameterMissing (param is missing or the value is empty: entry):
+  
+app/controllers/entries_controller.rb:42:in `entry_params'
+app/controllers/entries_controller.rb:32:in `update'
+Started GET "/" for ::1 at 2025-04-01 15:11:18 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 1.2ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 2.4ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.0ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 5.2ms | GC: 0.3ms)
+Completed 200 OK in 6ms (Views: 5.0ms | ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 0.5ms)
+
+
+Started PATCH "/entries/1" for ::1 at 2025-04-01 15:11:18 +0100
+Processing by EntriesController#update as TURBO_STREAM
+  Parameters: {"authenticity_token"=>"[FILTERED]", "id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:31:in `update'
+Completed 400 Bad Request in 5ms (ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.3ms)
+
+
+  
+ActionController::ParameterMissing (param is missing or the value is empty: entry):
+  
+app/controllers/entries_controller.rb:42:in `entry_params'
+app/controllers/entries_controller.rb:32:in `update'
+Started GET "/" for ::1 at 2025-04-01 15:11:18 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 1.2ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 2.4ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.0ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 5.2ms | GC: 0.3ms)
+Completed 200 OK in 6ms (Views: 4.9ms | ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 0.3ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:11:55 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 1.4ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 7.3ms | GC: 0.3ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.2ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 20.1ms | GC: 4.0ms)
+Completed 200 OK in 22ms (Views: 17.3ms | ActiveRecord: 3.5ms (1 query, 0 cached) | GC: 4.1ms)
+
+
+Started GET "/entries/1/edit" for ::1 at 2025-04-01 15:11:56 +0100
+  
+AbstractController::ActionNotFound (The action 'edit' could not be found for EntriesController):
+  
+actionpack (7.2.2.1) lib/abstract_controller/base.rb:158:in `process'
+actionview (7.2.2.1) lib/action_view/rendering.rb:40:in `process'
+actionpack (7.2.2.1) lib/action_controller/metal.rb:252:in `dispatch'
+actionpack (7.2.2.1) lib/action_controller/metal.rb:335:in `dispatch'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:67:in `dispatch'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:50:in `serve'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:53:in `block in serve'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:133:in `block in find_routes'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `each'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `find_routes'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:34:in `serve'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:896:in `call'
+rack (3.1.12) lib/rack/tempfile_reaper.rb:20:in `call'
+rack (3.1.12) lib/rack/etag.rb:29:in `call'
+rack (3.1.12) lib/rack/conditional_get.rb:31:in `call'
+rack (3.1.12) lib/rack/head.rb:15:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/http/permissions_policy.rb:38:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/http/content_security_policy.rb:38:in `call'
+rack-session (2.1.0) lib/rack/session/abstract/id.rb:274:in `context'
+rack-session (2.1.0) lib/rack/session/abstract/id.rb:268:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/cookies.rb:704:in `call'
+activerecord (7.2.2.1) lib/active_record/migration.rb:674:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:31:in `block in call'
+activesupport (7.2.2.1) lib/active_support/callbacks.rb:101:in `run_callbacks'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:30:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/actionable_exceptions.rb:18:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:31:in `call'
+web-console (4.2.1) lib/web_console/middleware.rb:132:in `call_app'
+web-console (4.2.1) lib/web_console/middleware.rb:28:in `block in call'
+web-console (4.2.1) lib/web_console/middleware.rb:17:in `catch'
+web-console (4.2.1) lib/web_console/middleware.rb:17:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/show_exceptions.rb:32:in `call'
+railties (7.2.2.1) lib/rails/rack/logger.rb:41:in `call_app'
+railties (7.2.2.1) lib/rails/rack/logger.rb:29:in `call'
+sprockets-rails (3.5.2) lib/sprockets/rails/quiet_assets.rb:17:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/remote_ip.rb:96:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/request_id.rb:33:in `call'
+rack (3.1.12) lib/rack/method_override.rb:28:in `call'
+rack (3.1.12) lib/rack/runtime.rb:24:in `call'
+activesupport (7.2.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:61:in `block in call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:26:in `collect_events'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:60:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/static.rb:27:in `call'
+rack (3.1.12) lib/rack/sendfile.rb:114:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/host_authorization.rb:143:in `call'
+railties (7.2.2.1) lib/rails/engine.rb:535:in `call'
+puma (6.6.0) lib/puma/configuration.rb:279:in `call'
+puma (6.6.0) lib/puma/request.rb:99:in `block in handle_request'
+puma (6.6.0) lib/puma/thread_pool.rb:390:in `with_force_shutdown'
+puma (6.6.0) lib/puma/request.rb:98:in `handle_request'
+puma (6.6.0) lib/puma/server.rb:472:in `process_client'
+puma (6.6.0) lib/puma/server.rb:254:in `block in run'
+puma (6.6.0) lib/puma/thread_pool.rb:167:in `block in spawn_thread'
+Started GET "/entries/1/edit" for ::1 at 2025-04-01 15:12:09 +0100
+  
+AbstractController::ActionNotFound (The action 'edit' could not be found for EntriesController):
+  
+actionpack (7.2.2.1) lib/abstract_controller/base.rb:158:in `process'
+actionview (7.2.2.1) lib/action_view/rendering.rb:40:in `process'
+actionpack (7.2.2.1) lib/action_controller/metal.rb:252:in `dispatch'
+actionpack (7.2.2.1) lib/action_controller/metal.rb:335:in `dispatch'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:67:in `dispatch'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:50:in `serve'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:53:in `block in serve'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:133:in `block in find_routes'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `each'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `find_routes'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:34:in `serve'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:896:in `call'
+rack (3.1.12) lib/rack/tempfile_reaper.rb:20:in `call'
+rack (3.1.12) lib/rack/etag.rb:29:in `call'
+rack (3.1.12) lib/rack/conditional_get.rb:31:in `call'
+rack (3.1.12) lib/rack/head.rb:15:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/http/permissions_policy.rb:38:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/http/content_security_policy.rb:38:in `call'
+rack-session (2.1.0) lib/rack/session/abstract/id.rb:274:in `context'
+rack-session (2.1.0) lib/rack/session/abstract/id.rb:268:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/cookies.rb:704:in `call'
+activerecord (7.2.2.1) lib/active_record/migration.rb:674:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:31:in `block in call'
+activesupport (7.2.2.1) lib/active_support/callbacks.rb:101:in `run_callbacks'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:30:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/actionable_exceptions.rb:18:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:31:in `call'
+web-console (4.2.1) lib/web_console/middleware.rb:132:in `call_app'
+web-console (4.2.1) lib/web_console/middleware.rb:28:in `block in call'
+web-console (4.2.1) lib/web_console/middleware.rb:17:in `catch'
+web-console (4.2.1) lib/web_console/middleware.rb:17:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/show_exceptions.rb:32:in `call'
+railties (7.2.2.1) lib/rails/rack/logger.rb:41:in `call_app'
+railties (7.2.2.1) lib/rails/rack/logger.rb:29:in `call'
+sprockets-rails (3.5.2) lib/sprockets/rails/quiet_assets.rb:17:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/remote_ip.rb:96:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/request_id.rb:33:in `call'
+rack (3.1.12) lib/rack/method_override.rb:28:in `call'
+rack (3.1.12) lib/rack/runtime.rb:24:in `call'
+activesupport (7.2.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:61:in `block in call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:26:in `collect_events'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:60:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/static.rb:27:in `call'
+rack (3.1.12) lib/rack/sendfile.rb:114:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/host_authorization.rb:143:in `call'
+railties (7.2.2.1) lib/rails/engine.rb:535:in `call'
+puma (6.6.0) lib/puma/configuration.rb:279:in `call'
+puma (6.6.0) lib/puma/request.rb:99:in `block in handle_request'
+puma (6.6.0) lib/puma/thread_pool.rb:390:in `with_force_shutdown'
+puma (6.6.0) lib/puma/request.rb:98:in `handle_request'
+puma (6.6.0) lib/puma/server.rb:472:in `process_client'
+puma (6.6.0) lib/puma/server.rb:254:in `block in run'
+puma (6.6.0) lib/puma/thread_pool.rb:167:in `block in spawn_thread'
+Started GET "/entries/1/edit" for ::1 at 2025-04-01 15:12:10 +0100
+  
+AbstractController::ActionNotFound (The action 'edit' could not be found for EntriesController):
+  
+actionpack (7.2.2.1) lib/abstract_controller/base.rb:158:in `process'
+actionview (7.2.2.1) lib/action_view/rendering.rb:40:in `process'
+actionpack (7.2.2.1) lib/action_controller/metal.rb:252:in `dispatch'
+actionpack (7.2.2.1) lib/action_controller/metal.rb:335:in `dispatch'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:67:in `dispatch'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:50:in `serve'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:53:in `block in serve'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:133:in `block in find_routes'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `each'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `find_routes'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:34:in `serve'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:896:in `call'
+rack (3.1.12) lib/rack/tempfile_reaper.rb:20:in `call'
+rack (3.1.12) lib/rack/etag.rb:29:in `call'
+rack (3.1.12) lib/rack/conditional_get.rb:31:in `call'
+rack (3.1.12) lib/rack/head.rb:15:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/http/permissions_policy.rb:38:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/http/content_security_policy.rb:38:in `call'
+rack-session (2.1.0) lib/rack/session/abstract/id.rb:274:in `context'
+rack-session (2.1.0) lib/rack/session/abstract/id.rb:268:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/cookies.rb:704:in `call'
+activerecord (7.2.2.1) lib/active_record/migration.rb:674:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:31:in `block in call'
+activesupport (7.2.2.1) lib/active_support/callbacks.rb:101:in `run_callbacks'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:30:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/actionable_exceptions.rb:18:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:31:in `call'
+web-console (4.2.1) lib/web_console/middleware.rb:132:in `call_app'
+web-console (4.2.1) lib/web_console/middleware.rb:28:in `block in call'
+web-console (4.2.1) lib/web_console/middleware.rb:17:in `catch'
+web-console (4.2.1) lib/web_console/middleware.rb:17:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/show_exceptions.rb:32:in `call'
+railties (7.2.2.1) lib/rails/rack/logger.rb:41:in `call_app'
+railties (7.2.2.1) lib/rails/rack/logger.rb:29:in `call'
+sprockets-rails (3.5.2) lib/sprockets/rails/quiet_assets.rb:17:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/remote_ip.rb:96:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/request_id.rb:33:in `call'
+rack (3.1.12) lib/rack/method_override.rb:28:in `call'
+rack (3.1.12) lib/rack/runtime.rb:24:in `call'
+activesupport (7.2.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:61:in `block in call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:26:in `collect_events'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:60:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/static.rb:27:in `call'
+rack (3.1.12) lib/rack/sendfile.rb:114:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/host_authorization.rb:143:in `call'
+railties (7.2.2.1) lib/rails/engine.rb:535:in `call'
+puma (6.6.0) lib/puma/configuration.rb:279:in `call'
+puma (6.6.0) lib/puma/request.rb:99:in `block in handle_request'
+puma (6.6.0) lib/puma/thread_pool.rb:390:in `with_force_shutdown'
+puma (6.6.0) lib/puma/request.rb:98:in `handle_request'
+puma (6.6.0) lib/puma/server.rb:472:in `process_client'
+puma (6.6.0) lib/puma/server.rb:254:in `block in run'
+puma (6.6.0) lib/puma/thread_pool.rb:167:in `block in spawn_thread'
+Started GET "/entries/1" for ::1 at 2025-04-01 15:12:13 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 2.8ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.4ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 17.7ms | GC: 1.5ms)
+Completed 200 OK in 47ms (Views: 19.5ms | ActiveRecord: 5.4ms (1 query, 0 cached) | GC: 2.1ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:12:15 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.7ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 5.3ms | GC: 0.4ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 10.4ms | GC: 0.7ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 15.7ms | GC: 1.1ms)
+Completed 200 OK in 18ms (Views: 15.6ms | ActiveRecord: 0.7ms (1 query, 0 cached) | GC: 1.1ms)
+
+
+Started GET "/?class=button" for ::1 at 2025-04-01 15:12:16 +0100
+Processing by EntriesController#index as HTML
+  Parameters: {"class"=>"button"}
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.5ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 4.7ms | GC: 0.4ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 7.6ms | GC: 0.4ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 16.4ms | GC: 1.0ms)
+Completed 200 OK in 18ms (Views: 16.3ms | ActiveRecord: 0.5ms (1 query, 0 cached) | GC: 1.0ms)
+
+
+Started GET "/?class=button" for ::1 at 2025-04-01 15:12:17 +0100
+Processing by EntriesController#index as HTML
+  Parameters: {"class"=>"button"}
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (1.0ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 3.7ms | GC: 0.4ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 6.8ms | GC: 0.6ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 13.3ms | GC: 1.1ms)
+Completed 200 OK in 15ms (Views: 12.7ms | ActiveRecord: 1.0ms (1 query, 0 cached) | GC: 1.1ms)
+
+
+Started GET "/?class=button" for ::1 at 2025-04-01 15:12:17 +0100
+Processing by EntriesController#index as HTML
+  Parameters: {"class"=>"button"}
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.7ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 1.9ms | GC: 0.2ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 4.0ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 8.8ms | GC: 0.6ms)
+Completed 200 OK in 10ms (Views: 8.6ms | ActiveRecord: 0.7ms (1 query, 0 cached) | GC: 0.6ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:12:17 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.8ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 4.0ms | GC: 0.4ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 9.1ms | GC: 0.8ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 18.1ms | GC: 1.6ms)
+Completed 200 OK in 21ms (Views: 18.6ms | ActiveRecord: 0.8ms (1 query, 0 cached) | GC: 1.6ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:13:26 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 1.2ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 7.4ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.2ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 16.4ms | GC: 0.7ms)
+Completed 200 OK in 18ms (Views: 13.0ms | ActiveRecord: 4.0ms (1 query, 0 cached) | GC: 0.7ms)
+
+
+Started GET "/entries/4/edit" for ::1 at 2025-04-01 15:13:27 +0100
+  
+AbstractController::ActionNotFound (The action 'edit' could not be found for EntriesController):
+  
+actionpack (7.2.2.1) lib/abstract_controller/base.rb:158:in `process'
+actionview (7.2.2.1) lib/action_view/rendering.rb:40:in `process'
+actionpack (7.2.2.1) lib/action_controller/metal.rb:252:in `dispatch'
+actionpack (7.2.2.1) lib/action_controller/metal.rb:335:in `dispatch'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:67:in `dispatch'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:50:in `serve'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:53:in `block in serve'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:133:in `block in find_routes'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `each'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `find_routes'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:34:in `serve'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:896:in `call'
+rack (3.1.12) lib/rack/tempfile_reaper.rb:20:in `call'
+rack (3.1.12) lib/rack/etag.rb:29:in `call'
+rack (3.1.12) lib/rack/conditional_get.rb:31:in `call'
+rack (3.1.12) lib/rack/head.rb:15:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/http/permissions_policy.rb:38:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/http/content_security_policy.rb:38:in `call'
+rack-session (2.1.0) lib/rack/session/abstract/id.rb:274:in `context'
+rack-session (2.1.0) lib/rack/session/abstract/id.rb:268:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/cookies.rb:704:in `call'
+activerecord (7.2.2.1) lib/active_record/migration.rb:674:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:31:in `block in call'
+activesupport (7.2.2.1) lib/active_support/callbacks.rb:101:in `run_callbacks'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:30:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/actionable_exceptions.rb:18:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:31:in `call'
+web-console (4.2.1) lib/web_console/middleware.rb:132:in `call_app'
+web-console (4.2.1) lib/web_console/middleware.rb:28:in `block in call'
+web-console (4.2.1) lib/web_console/middleware.rb:17:in `catch'
+web-console (4.2.1) lib/web_console/middleware.rb:17:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/show_exceptions.rb:32:in `call'
+railties (7.2.2.1) lib/rails/rack/logger.rb:41:in `call_app'
+railties (7.2.2.1) lib/rails/rack/logger.rb:29:in `call'
+sprockets-rails (3.5.2) lib/sprockets/rails/quiet_assets.rb:17:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/remote_ip.rb:96:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/request_id.rb:33:in `call'
+rack (3.1.12) lib/rack/method_override.rb:28:in `call'
+rack (3.1.12) lib/rack/runtime.rb:24:in `call'
+activesupport (7.2.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:61:in `block in call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:26:in `collect_events'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:60:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/static.rb:27:in `call'
+rack (3.1.12) lib/rack/sendfile.rb:114:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/host_authorization.rb:143:in `call'
+railties (7.2.2.1) lib/rails/engine.rb:535:in `call'
+puma (6.6.0) lib/puma/configuration.rb:279:in `call'
+puma (6.6.0) lib/puma/request.rb:99:in `block in handle_request'
+puma (6.6.0) lib/puma/thread_pool.rb:390:in `with_force_shutdown'
+puma (6.6.0) lib/puma/request.rb:98:in `handle_request'
+puma (6.6.0) lib/puma/server.rb:472:in `process_client'
+puma (6.6.0) lib/puma/server.rb:254:in `block in run'
+puma (6.6.0) lib/puma/thread_pool.rb:167:in `block in spawn_thread'
+Started GET "/" for ::1 at 2025-04-01 15:13:27 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 0.9ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 2.0ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.0ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 4.7ms | GC: 0.2ms)
+Completed 200 OK in 5ms (Views: 4.5ms | ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 0.3ms)
+
+
+Started GET "/entries/4/edit" for ::1 at 2025-04-01 15:13:28 +0100
+  
+AbstractController::ActionNotFound (The action 'edit' could not be found for EntriesController):
+  
+actionpack (7.2.2.1) lib/abstract_controller/base.rb:158:in `process'
+actionview (7.2.2.1) lib/action_view/rendering.rb:40:in `process'
+actionpack (7.2.2.1) lib/action_controller/metal.rb:252:in `dispatch'
+actionpack (7.2.2.1) lib/action_controller/metal.rb:335:in `dispatch'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:67:in `dispatch'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:50:in `serve'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:53:in `block in serve'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:133:in `block in find_routes'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `each'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `find_routes'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:34:in `serve'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:896:in `call'
+rack (3.1.12) lib/rack/tempfile_reaper.rb:20:in `call'
+rack (3.1.12) lib/rack/etag.rb:29:in `call'
+rack (3.1.12) lib/rack/conditional_get.rb:31:in `call'
+rack (3.1.12) lib/rack/head.rb:15:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/http/permissions_policy.rb:38:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/http/content_security_policy.rb:38:in `call'
+rack-session (2.1.0) lib/rack/session/abstract/id.rb:274:in `context'
+rack-session (2.1.0) lib/rack/session/abstract/id.rb:268:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/cookies.rb:704:in `call'
+activerecord (7.2.2.1) lib/active_record/migration.rb:674:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:31:in `block in call'
+activesupport (7.2.2.1) lib/active_support/callbacks.rb:101:in `run_callbacks'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:30:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/actionable_exceptions.rb:18:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:31:in `call'
+web-console (4.2.1) lib/web_console/middleware.rb:132:in `call_app'
+web-console (4.2.1) lib/web_console/middleware.rb:28:in `block in call'
+web-console (4.2.1) lib/web_console/middleware.rb:17:in `catch'
+web-console (4.2.1) lib/web_console/middleware.rb:17:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/show_exceptions.rb:32:in `call'
+railties (7.2.2.1) lib/rails/rack/logger.rb:41:in `call_app'
+railties (7.2.2.1) lib/rails/rack/logger.rb:29:in `call'
+sprockets-rails (3.5.2) lib/sprockets/rails/quiet_assets.rb:17:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/remote_ip.rb:96:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/request_id.rb:33:in `call'
+rack (3.1.12) lib/rack/method_override.rb:28:in `call'
+rack (3.1.12) lib/rack/runtime.rb:24:in `call'
+activesupport (7.2.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:61:in `block in call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:26:in `collect_events'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:60:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/static.rb:27:in `call'
+rack (3.1.12) lib/rack/sendfile.rb:114:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/host_authorization.rb:143:in `call'
+railties (7.2.2.1) lib/rails/engine.rb:535:in `call'
+puma (6.6.0) lib/puma/configuration.rb:279:in `call'
+puma (6.6.0) lib/puma/request.rb:99:in `block in handle_request'
+puma (6.6.0) lib/puma/thread_pool.rb:390:in `with_force_shutdown'
+puma (6.6.0) lib/puma/request.rb:98:in `handle_request'
+puma (6.6.0) lib/puma/server.rb:472:in `process_client'
+puma (6.6.0) lib/puma/server.rb:254:in `block in run'
+puma (6.6.0) lib/puma/thread_pool.rb:167:in `block in spawn_thread'
+Started GET "/" for ::1 at 2025-04-01 15:13:28 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 1.1ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 2.4ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.0ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 5.3ms | GC: 0.4ms)
+Completed 200 OK in 6ms (Views: 5.1ms | ActiveRecord: 0.3ms (1 query, 0 cached) | GC: 0.4ms)
+
+
+Started GET "/entries/4/edit" for ::1 at 2025-04-01 15:13:28 +0100
+  
+AbstractController::ActionNotFound (The action 'edit' could not be found for EntriesController):
+  
+actionpack (7.2.2.1) lib/abstract_controller/base.rb:158:in `process'
+actionview (7.2.2.1) lib/action_view/rendering.rb:40:in `process'
+actionpack (7.2.2.1) lib/action_controller/metal.rb:252:in `dispatch'
+actionpack (7.2.2.1) lib/action_controller/metal.rb:335:in `dispatch'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:67:in `dispatch'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:50:in `serve'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:53:in `block in serve'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:133:in `block in find_routes'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `each'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `find_routes'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:34:in `serve'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:896:in `call'
+rack (3.1.12) lib/rack/tempfile_reaper.rb:20:in `call'
+rack (3.1.12) lib/rack/etag.rb:29:in `call'
+rack (3.1.12) lib/rack/conditional_get.rb:31:in `call'
+rack (3.1.12) lib/rack/head.rb:15:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/http/permissions_policy.rb:38:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/http/content_security_policy.rb:38:in `call'
+rack-session (2.1.0) lib/rack/session/abstract/id.rb:274:in `context'
+rack-session (2.1.0) lib/rack/session/abstract/id.rb:268:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/cookies.rb:704:in `call'
+activerecord (7.2.2.1) lib/active_record/migration.rb:674:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:31:in `block in call'
+activesupport (7.2.2.1) lib/active_support/callbacks.rb:101:in `run_callbacks'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:30:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/actionable_exceptions.rb:18:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:31:in `call'
+web-console (4.2.1) lib/web_console/middleware.rb:132:in `call_app'
+web-console (4.2.1) lib/web_console/middleware.rb:28:in `block in call'
+web-console (4.2.1) lib/web_console/middleware.rb:17:in `catch'
+web-console (4.2.1) lib/web_console/middleware.rb:17:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/show_exceptions.rb:32:in `call'
+railties (7.2.2.1) lib/rails/rack/logger.rb:41:in `call_app'
+railties (7.2.2.1) lib/rails/rack/logger.rb:29:in `call'
+sprockets-rails (3.5.2) lib/sprockets/rails/quiet_assets.rb:17:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/remote_ip.rb:96:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/request_id.rb:33:in `call'
+rack (3.1.12) lib/rack/method_override.rb:28:in `call'
+rack (3.1.12) lib/rack/runtime.rb:24:in `call'
+activesupport (7.2.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:61:in `block in call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:26:in `collect_events'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:60:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/static.rb:27:in `call'
+rack (3.1.12) lib/rack/sendfile.rb:114:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/host_authorization.rb:143:in `call'
+railties (7.2.2.1) lib/rails/engine.rb:535:in `call'
+puma (6.6.0) lib/puma/configuration.rb:279:in `call'
+puma (6.6.0) lib/puma/request.rb:99:in `block in handle_request'
+puma (6.6.0) lib/puma/thread_pool.rb:390:in `with_force_shutdown'
+puma (6.6.0) lib/puma/request.rb:98:in `handle_request'
+puma (6.6.0) lib/puma/server.rb:472:in `process_client'
+puma (6.6.0) lib/puma/server.rb:254:in `block in run'
+puma (6.6.0) lib/puma/thread_pool.rb:167:in `block in spawn_thread'
+Started GET "/" for ::1 at 2025-04-01 15:13:28 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 1.1ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 2.3ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.0ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 5.3ms | GC: 0.4ms)
+Completed 200 OK in 6ms (Views: 5.1ms | ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 0.4ms)
+
+
+Started GET "/entries/4/edit" for ::1 at 2025-04-01 15:13:28 +0100
+  
+AbstractController::ActionNotFound (The action 'edit' could not be found for EntriesController):
+  
+actionpack (7.2.2.1) lib/abstract_controller/base.rb:158:in `process'
+actionview (7.2.2.1) lib/action_view/rendering.rb:40:in `process'
+actionpack (7.2.2.1) lib/action_controller/metal.rb:252:in `dispatch'
+actionpack (7.2.2.1) lib/action_controller/metal.rb:335:in `dispatch'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:67:in `dispatch'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:50:in `serve'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:53:in `block in serve'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:133:in `block in find_routes'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `each'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:126:in `find_routes'
+actionpack (7.2.2.1) lib/action_dispatch/journey/router.rb:34:in `serve'
+actionpack (7.2.2.1) lib/action_dispatch/routing/route_set.rb:896:in `call'
+rack (3.1.12) lib/rack/tempfile_reaper.rb:20:in `call'
+rack (3.1.12) lib/rack/etag.rb:29:in `call'
+rack (3.1.12) lib/rack/conditional_get.rb:31:in `call'
+rack (3.1.12) lib/rack/head.rb:15:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/http/permissions_policy.rb:38:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/http/content_security_policy.rb:38:in `call'
+rack-session (2.1.0) lib/rack/session/abstract/id.rb:274:in `context'
+rack-session (2.1.0) lib/rack/session/abstract/id.rb:268:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/cookies.rb:704:in `call'
+activerecord (7.2.2.1) lib/active_record/migration.rb:674:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:31:in `block in call'
+activesupport (7.2.2.1) lib/active_support/callbacks.rb:101:in `run_callbacks'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/callbacks.rb:30:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/actionable_exceptions.rb:18:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:31:in `call'
+web-console (4.2.1) lib/web_console/middleware.rb:132:in `call_app'
+web-console (4.2.1) lib/web_console/middleware.rb:28:in `block in call'
+web-console (4.2.1) lib/web_console/middleware.rb:17:in `catch'
+web-console (4.2.1) lib/web_console/middleware.rb:17:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/show_exceptions.rb:32:in `call'
+railties (7.2.2.1) lib/rails/rack/logger.rb:41:in `call_app'
+railties (7.2.2.1) lib/rails/rack/logger.rb:29:in `call'
+sprockets-rails (3.5.2) lib/sprockets/rails/quiet_assets.rb:17:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/remote_ip.rb:96:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/request_id.rb:33:in `call'
+rack (3.1.12) lib/rack/method_override.rb:28:in `call'
+rack (3.1.12) lib/rack/runtime.rb:24:in `call'
+activesupport (7.2.2.1) lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:61:in `block in call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:26:in `collect_events'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/server_timing.rb:60:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/executor.rb:16:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/static.rb:27:in `call'
+rack (3.1.12) lib/rack/sendfile.rb:114:in `call'
+actionpack (7.2.2.1) lib/action_dispatch/middleware/host_authorization.rb:143:in `call'
+railties (7.2.2.1) lib/rails/engine.rb:535:in `call'
+puma (6.6.0) lib/puma/configuration.rb:279:in `call'
+puma (6.6.0) lib/puma/request.rb:99:in `block in handle_request'
+puma (6.6.0) lib/puma/thread_pool.rb:390:in `with_force_shutdown'
+puma (6.6.0) lib/puma/request.rb:98:in `handle_request'
+puma (6.6.0) lib/puma/server.rb:472:in `process_client'
+puma (6.6.0) lib/puma/server.rb:254:in `block in run'
+puma (6.6.0) lib/puma/thread_pool.rb:167:in `block in spawn_thread'
+Started GET "/" for ::1 at 2025-04-01 15:13:28 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 1.1ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 2.4ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.0ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 5.7ms | GC: 0.4ms)
+Completed 200 OK in 6ms (Views: 5.5ms | ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 0.4ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:13:42 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.5ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 1.4ms | GC: 0.1ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 9.7ms | GC: 0.4ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.2ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 18.0ms | GC: 1.2ms)
+Completed 200 OK in 20ms (Views: 13.1ms | ActiveRecord: 5.6ms (1 query, 0 cached) | GC: 1.3ms)
+
+
+Started GET "/entries/2" for ::1 at 2025-04-01 15:13:43 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"2"}
+  [1m[36mEntry Load (0.3ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 3.4ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 7.7ms | GC: 0.5ms)
+Completed 200 OK in 13ms (Views: 8.0ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 1.0ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:13:44 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.5ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 2.9ms | GC: 0.3ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 5.2ms | GC: 0.3ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 16.7ms | GC: 0.9ms)
+Completed 200 OK in 18ms (Views: 16.7ms | ActiveRecord: 0.5ms (1 query, 0 cached) | GC: 0.9ms)
+
+
+Started GET "/entries/1" for ::1 at 2025-04-01 15:13:46 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"1"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 2.2ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 8.5ms | GC: 0.5ms)
+Completed 200 OK in 11ms (Views: 8.8ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.5ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:13:46 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.5ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 2.2ms | GC: 0.2ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 4.5ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 13.8ms | GC: 0.6ms)
+Completed 200 OK in 15ms (Views: 13.7ms | ActiveRecord: 0.5ms (1 query, 0 cached) | GC: 0.6ms)
+
+
+Started GET "/entries/2" for ::1 at 2025-04-01 15:13:47 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"2"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.9ms | GC: 0.0ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 6.9ms | GC: 0.3ms)
+Completed 200 OK in 10ms (Views: 7.3ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.6ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:13:48 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 3.1ms | GC: 0.3ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 5.7ms | GC: 0.5ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 12.3ms | GC: 0.8ms)
+Completed 200 OK in 13ms (Views: 12.2ms | ActiveRecord: 0.4ms (1 query, 0 cached) | GC: 0.8ms)
+
+
+Started GET "/entries/4" for ::1 at 2025-04-01 15:13:49 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"4"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 4], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 2.4ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 8.3ms | GC: 0.4ms)
+Completed 200 OK in 12ms (Views: 8.6ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.4ms)
+
+
+Started GET "/entries" for ::1 at 2025-04-01 15:13:49 +0100
+  
+ActionController::RoutingError (No route matches [GET] "/entries"):
+  
+Started GET "/entries/new" for ::1 at 2025-04-01 15:13:50 +0100
+Processing by EntriesController#new as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/new.html.erb within layouts/application
+  Rendered entries/new.html.erb within layouts/application (Duration: 2.2ms | GC: 0.0ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 8.7ms | GC: 0.5ms)
+Completed 200 OK in 11ms (Views: 9.0ms | ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 0.5ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:13:50 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.5ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 2.3ms | GC: 0.2ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 6.5ms | GC: 0.4ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 14.1ms | GC: 0.8ms)
+Completed 200 OK in 15ms (Views: 14.0ms | ActiveRecord: 0.5ms (1 query, 0 cached) | GC: 0.8ms)
+
+
+Started GET "/entries/6" for ::1 at 2025-04-01 15:13:52 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"6"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.9ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 9.6ms | GC: 0.6ms)
+Completed 200 OK in 13ms (Views: 9.9ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.6ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:13:53 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.6ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 3.2ms | GC: 0.3ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 6.2ms | GC: 0.3ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 14.2ms | GC: 0.8ms)
+Completed 200 OK in 16ms (Views: 14.2ms | ActiveRecord: 0.6ms (1 query, 0 cached) | GC: 0.8ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:14:06 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.4ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 3.9ms | GC: 2.7ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 10.3ms | GC: 2.8ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.2ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 18.2ms | GC: 3.9ms)
+Completed 200 OK in 20ms (Views: 14.6ms | ActiveRecord: 4.3ms (1 query, 0 cached) | GC: 3.9ms)
+
+
+Started GET "/" for ::1 at 2025-04-01 15:14:07 +0100
+Processing by EntriesController#index as HTML
+  Rendering layout layouts/application.html.erb
+  Rendering entries/index.html.erb within layouts/application
+  [1m[36mEntry Load (0.5ms)[0m  [1m[34mSELECT "entries".* FROM "entries"[0m
+  ↳ app/views/entries/index.html.erb:3
+  Rendered collection of shared/_entry.html.erb [5 times] (Duration: 2.7ms | GC: 0.2ms)
+  Rendered entries/index.html.erb within layouts/application (Duration: 5.6ms | GC: 0.5ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 10.1ms | GC: 0.7ms)
+Completed 200 OK in 11ms (Views: 9.9ms | ActiveRecord: 0.5ms (1 query, 0 cached) | GC: 0.7ms)
+
+
+Started GET "/entries/2" for ::1 at 2025-04-01 15:14:08 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"2"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 2.0ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 5.7ms | GC: 0.3ms)
+Completed 200 OK in 10ms (Views: 6.1ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.6ms)
+
+
+Started GET "/entries/2" for ::1 at 2025-04-01 15:14:26 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"2"}
+  [1m[36mEntry Load (0.1ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.1ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.2ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 8.6ms | GC: 0.7ms)
+Completed 200 OK in 17ms (Views: 9.3ms | ActiveRecord: 4.7ms (1 query, 0 cached) | GC: 0.9ms)
+
+
+Started GET "/entries/2" for ::1 at 2025-04-01 15:14:27 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"2"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 2.7ms | GC: 0.3ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 7.4ms | GC: 0.5ms)
+Completed 200 OK in 11ms (Views: 7.8ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 0.5ms)
+
+
+Started GET "/entries/2" for ::1 at 2025-04-01 15:14:55 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"2"}
+  [1m[36mEntry Load (0.1ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 261.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 261.7ms | GC: 0.0ms)
+Completed 500 Internal Server Error in 270ms (ActiveRecord: 3.5ms (1 query, 0 cached) | GC: 0.3ms)
+
+
+  
+ActionView::SyntaxErrorInTemplate (Encountered a syntax error while rendering template: check <h1>Entry <%=@entry.name</h1>
+
+<%= form_with(model: @entry, method: :patch) do |form| %>
+  <div>
+    <%= @entry.name %>
+    <%= form.label :name %>
+    <%= form.text_field :name %>
+    <br/>
+    <%= @entry.link %>
+    <%= form.label :link %>
+    <%= form.text_field :link %>
+  </div>
+  
+  <div>
+    <%= form.submit "Update Entry" %>
+  </div>
+<% end %>
+
+<br>
+
+<div>
+  <%= link_to "Back to entries", entries_path %>
+  <%= link_to "Show this entry", @entry %>
+</div>
+):
+
+Causes:
+ActiveSupport::SyntaxErrorProxy (/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/entries/show.html.erb:12: syntax error, unexpected '<', expecting `end'
+  </div>
+  ^
+/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/entries/show.html.erb:16: unknown regexp options - dv
+  </div>
+   ^~~~
+/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/entries/show.html.erb:19: syntax error, unexpected '<', expecting `end'
+/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/entries/show.html.erb:24: syntax error, unexpected '<', expecting `end'
+</div>'.freeze;
+^
+/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/entries/show.html.erb:25: unknown regexp options - vw
+...safe_append='<!-- END app/views/entries/show.html.erb -->';@...
+...                         ^~~~~~
+/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/entries/show.html.erb:25: syntax error, unexpected unary-, expecting `end'
+...p/views/entries/show.html.erb -->';@output_buffer
+...                              ^
+/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/entries/show.html.erb:26: unterminated string meets end of file
+          end
+             ^
+/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/entries/show.html.erb:26: syntax error, unexpected end-of-input, expecting `end'
+          end
+             ^
+)
+1:    <h1>Entry <%=@entry.name</h1>
+2:    
+3:    <%= form_with(model: @entry, method: :patch) do |form| %>
+4:      <div>
+5:        <%= @entry.name %>
+6:        <%= form.label :name %>
+7:        <%= form.text_field :name %>
+8:        <br/>
+9:        <%= @entry.link %>
+10:        <%= form.label :link %>
+11:        <%= form.text_field :link %>
+12:      </div>
+13:      
+14:      <div>
+15:        <%= form.submit "Update Entry" %>
+16:      </div>
+17:    <% end %>
+18:    
+19:    <br>
+20:    
+21:    <div>
+22:      <%= link_to "Back to entries", entries_path %>
+23:      <%= link_to "Show this entry", @entry %>
+24:    </div>
+  
+app/views/entries/show.html.erb:12: syntax error, unexpected '<', expecting `end'
+app/views/entries/show.html.erb:16: unknown regexp options - dv
+app/views/entries/show.html.erb:19: syntax error, unexpected '<', expecting `end'
+app/views/entries/show.html.erb:24: syntax error, unexpected '<', expecting `end'
+app/views/entries/show.html.erb:25: unknown regexp options - vw
+app/views/entries/show.html.erb:25: syntax error, unexpected unary-, expecting `end'
+app/views/entries/show.html.erb:26: unterminated string meets end of file
+app/views/entries/show.html.erb:26: syntax error, unexpected end-of-input, expecting `end'
+Started GET "/entries/2" for ::1 at 2025-04-01 15:15:01 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"2"}
+  [1m[36mEntry Load (1.3ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 2.3ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 2.8ms | GC: 0.0ms)
+Completed 500 Internal Server Error in 13ms (ActiveRecord: 1.2ms (1 query, 0 cached) | GC: 0.4ms)
+
+
+  
+ActionView::SyntaxErrorInTemplate (Encountered a syntax error while rendering template: check <h1>Entry <%=@entry.name</h1>
+
+<%= form_with(model: @entry, method: :patch) do |form| %>
+  <div>
+    <%= @entry.name %>
+    <%= form.label :name %>
+    <%= form.text_field :name %>
+    <br/>
+    <%= @entry.link %>
+    <%= form.label :link %>
+    <%= form.text_field :link %>
+  </div>
+  
+  <div>
+    <%= form.submit "Update Entry" %>
+  </div>
+<% end %>
+
+<br>
+
+<div>
+  <%= link_to "Back to entries", entries_path %>
+  <%= link_to "Show this entry", @entry %>
+</div>
+):
+
+Causes:
+ActiveSupport::SyntaxErrorProxy (/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/entries/show.html.erb:12: syntax error, unexpected '<', expecting `end'
+  </div>
+  ^
+/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/entries/show.html.erb:16: unknown regexp options - dv
+  </div>
+   ^~~~
+/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/entries/show.html.erb:19: syntax error, unexpected '<', expecting `end'
+/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/entries/show.html.erb:24: syntax error, unexpected '<', expecting `end'
+</div>'.freeze;
+^
+/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/entries/show.html.erb:25: unknown regexp options - vw
+...safe_append='<!-- END app/views/entries/show.html.erb -->';@...
+...                         ^~~~~~
+/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/entries/show.html.erb:25: syntax error, unexpected unary-, expecting `end'
+...p/views/entries/show.html.erb -->';@output_buffer
+...                              ^
+/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/entries/show.html.erb:26: unterminated string meets end of file
+          end
+             ^
+/Users/joshuagray/Documents/grad-training/ruby-journal-app/journal-app/app/views/entries/show.html.erb:26: syntax error, unexpected end-of-input, expecting `end'
+          end
+             ^
+)
+1:    <h1>Entry <%=@entry.name</h1>
+2:    
+3:    <%= form_with(model: @entry, method: :patch) do |form| %>
+4:      <div>
+5:        <%= @entry.name %>
+6:        <%= form.label :name %>
+7:        <%= form.text_field :name %>
+8:        <br/>
+9:        <%= @entry.link %>
+10:        <%= form.label :link %>
+11:        <%= form.text_field :link %>
+12:      </div>
+13:      
+14:      <div>
+15:        <%= form.submit "Update Entry" %>
+16:      </div>
+17:    <% end %>
+18:    
+19:    <br>
+20:    
+21:    <div>
+22:      <%= link_to "Back to entries", entries_path %>
+23:      <%= link_to "Show this entry", @entry %>
+24:    </div>
+  
+app/views/entries/show.html.erb:12: syntax error, unexpected '<', expecting `end'
+app/views/entries/show.html.erb:16: unknown regexp options - dv
+app/views/entries/show.html.erb:19: syntax error, unexpected '<', expecting `end'
+app/views/entries/show.html.erb:24: syntax error, unexpected '<', expecting `end'
+app/views/entries/show.html.erb:25: unknown regexp options - vw
+app/views/entries/show.html.erb:25: syntax error, unexpected unary-, expecting `end'
+app/views/entries/show.html.erb:26: unterminated string meets end of file
+app/views/entries/show.html.erb:26: syntax error, unexpected end-of-input, expecting `end'
+Started GET "/entries/2" for ::1 at 2025-04-01 15:15:07 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"2"}
+  [1m[36mEntry Load (0.1ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.0ms | GC: 0.0ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 8.3ms | GC: 0.7ms)
+Completed 200 OK in 15ms (Views: 9.0ms | ActiveRecord: 3.0ms (1 query, 0 cached) | GC: 1.0ms)
+
+
+Started GET "/entries/2" for ::1 at 2025-04-01 15:15:08 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"2"}
+  [1m[36mEntry Load (0.3ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 2.2ms | GC: 0.0ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 10.3ms | GC: 3.9ms)
+Completed 200 OK in 15ms (Views: 10.6ms | ActiveRecord: 0.2ms (1 query, 0 cached) | GC: 4.2ms)
+
+
+Started GET "/entries/2" for ::1 at 2025-04-01 15:15:09 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"2"}
+  [1m[36mEntry Load (0.3ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.8ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 5.9ms | GC: 0.5ms)
+Completed 200 OK in 9ms (Views: 6.3ms | ActiveRecord: 0.3ms (1 query, 0 cached) | GC: 0.5ms)
+
+
+Started PATCH "/entries/2" for ::1 at 2025-04-01 15:15:13 +0100
+Processing by EntriesController#update as TURBO_STREAM
+  Parameters: {"authenticity_token"=>"[FILTERED]", "entry"=>{"name"=>"test entry", "link"=>""}, "commit"=>"Update Entry", "id"=>"2"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:31:in `update'
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/entries_controller.rb:32:in `update'
+  [1m[36mEntry Update (1.8ms)[0m  [1m[33mUPDATE "entries" SET "name" = $1, "updated_at" = $2, "link" = $3 WHERE "entries"."id" = $4[0m  [["name", "test entry"], ["updated_at", "2025-04-01 14:15:13.314812"], ["link", ""], ["id", 2]]
+  ↳ app/controllers/entries_controller.rb:32:in `update'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/entries_controller.rb:32:in `update'
+Redirected to http://localhost:3000/entries/2
+Completed 302 Found in 11ms (ActiveRecord: 2.3ms (2 queries, 0 cached) | GC: 0.6ms)
+
+
+Started GET "/entries/2" for ::1 at 2025-04-01 15:15:13 +0100
+Processing by EntriesController#show as TURBO_STREAM
+  Parameters: {"id"=>"2"}
+  [1m[36mEntry Load (0.2ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.9ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 6.5ms | GC: 0.5ms)
+Completed 200 OK in 9ms (Views: 7.0ms | ActiveRecord: 0.1ms (1 query, 0 cached) | GC: 0.5ms)
+
+
+Started GET "/entries/2" for ::1 at 2025-04-01 15:15:20 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"2"}
+  [1m[36mEntry Load (0.1ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.0ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 8.1ms | GC: 0.6ms)
+Completed 200 OK in 16ms (Views: 8.8ms | ActiveRecord: 3.7ms (1 query, 0 cached) | GC: 0.8ms)
+
+
+Started GET "/entries/2" for ::1 at 2025-04-01 15:15:21 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"2"}
+  [1m[36mEntry Load (0.3ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 4.0ms | GC: 0.2ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 11.3ms | GC: 0.6ms)
+Completed 200 OK in 17ms (Views: 11.9ms | ActiveRecord: 0.3ms (1 query, 0 cached) | GC: 1.0ms)
+
+
+Started GET "/entries/2" for ::1 at 2025-04-01 15:15:27 +0100
+Processing by EntriesController#show as HTML
+  Parameters: {"id"=>"2"}
+  [1m[36mEntry Load (0.1ms)[0m  [1m[34mSELECT "entries".* FROM "entries" WHERE "entries"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/entries_controller.rb:21:in `show'
+  Rendering layout layouts/application.html.erb
+  Rendering entries/show.html.erb within layouts/application
+  Rendered entries/show.html.erb within layouts/application (Duration: 1.1ms | GC: 0.1ms)
+  Rendered shared/_navbar.html.erb (Duration: 0.1ms | GC: 0.0ms)
+  Rendered layout layouts/application.html.erb (Duration: 8.4ms | GC: 1.0ms)
+Completed 200 OK in 15ms (Views: 9.1ms | ActiveRecord: 3.1ms (1 query, 0 cached) | GC: 1.2ms)
+
+


### PR DESCRIPTION
# Implement new page and functionality to allow users to view and edit an entry

## changes

### _entry.html.erb
- Moved logic to render each entry, as well as an edit and delete button
- Added an `edit entry` button, which links to a show page for that specific entry. Might rename depending on how additional functionality is organised.

### index.html.erb
- Now renders a partial for item in the collection of entries instead of iterating in the page

### show.html.erb
- List all information associated with a given entry
- Include the ability to update the existing entry through form

### Other changes
- entries_controller now has `update` method
- added `show` and `update` to routes.db
